### PR TITLE
Annotation support

### DIFF
--- a/choral/src/main/antlr4/Choral.g4
+++ b/choral/src/main/antlr4/Choral.g4
@@ -141,7 +141,7 @@ typeDeclaration
  */
 
 classDeclaration
-	: annotations? classModifier* CLASS Identifier worldParameters typeParameters? superClass? superInterfaces? classBody
+	: annotation* classModifier* CLASS Identifier worldParameters typeParameters? superClass? superInterfaces? classBody
 	;
 
 classModifier
@@ -210,7 +210,7 @@ fieldModifier
 	;
 
 methodDeclaration
-	: annotations? methodModifier* methodHeader methodBody
+	: annotation* methodModifier* methodHeader methodBody
 	;
 
 methodModifier
@@ -272,7 +272,7 @@ explicitConstructorInvocation
     ;
 
 enumDeclaration
-	: annotations? classModifier* ENUM Identifier AT worldParameter enumBody
+	: annotation* classModifier* ENUM Identifier AT worldParameter enumBody
 	;
 
 enumBody
@@ -292,7 +292,7 @@ enumConstant
  */
 
 interfaceDeclaration
-	: annotations? interfaceModifier* INTERFACE Identifier worldParameters typeParameters? extendsInterfaces? interfaceBody
+	: annotation* interfaceModifier* INTERFACE Identifier worldParameters typeParameters? extendsInterfaces? interfaceBody
 	;
 
 interfaceModifier
@@ -312,7 +312,7 @@ interfaceBody
 	;
 
 interfaceMethodDeclaration
-	: annotations? interfaceMethodModifier* methodHeader SEMI
+	: annotation* interfaceMethodModifier* methodHeader SEMI
 	;
 
 interfaceMethodModifier
@@ -323,8 +323,8 @@ interfaceMethodModifier
 //	|	'static'
 	;
 
-annotations
-	: AT Identifier ( LPAREN annotationValues RPAREN )? annotations?
+annotation
+	: AT Identifier ( LPAREN annotationValues RPAREN )?
 	;
 
 annotationValues

--- a/choral/src/main/antlr4/Choral.g4
+++ b/choral/src/main/antlr4/Choral.g4
@@ -44,6 +44,10 @@ literal
 	| StringLiteral
 	;
 
+/*
+ * Productions from §4 (Types, Values, and Variables)
+ */
+
 referenceType
 	: Identifier worldArguments? typeArguments?
 	;
@@ -85,6 +89,10 @@ typeArgumentList
 	: referenceType ( COMMA referenceType )*
 	;
 
+/*
+ * Productions from §6 (Names)
+ */
+
 expressionName
 	: Identifier
 	| ambiguousName DOT Identifier
@@ -93,6 +101,11 @@ expressionName
 ambiguousName
 	: Identifier
 	| ambiguousName DOT Identifier
+	;
+
+qualifiedName
+	: Identifier
+	| qualifiedName DOT Identifier
 	;
 
 /*
@@ -117,23 +130,10 @@ importDeclaration
 	: IMPORT qualifiedName (DOT STAR)? SEMI
 	;
 
-qualifiedName
-	: Identifier
-	| qualifiedName DOT Identifier
-	;
-
 typeDeclaration
 	: classDeclaration
 	| interfaceDeclaration
 	| enumDeclaration
-	;
-
-annotations
-	: AT Identifier ( LPAREN annotationValues RPAREN )? annotations?
-	;
-
-annotationValues
- 	: Identifier ASSIGN literal ( COMMA annotationValues )?
 	;
 
 /*
@@ -271,32 +271,8 @@ explicitConstructorInvocation
     |	typeArguments? SUPER LPAREN argumentList? RPAREN SEMI
     ;
 
-/*
- * Productions from §9 (Interfaces), added enums
- */
-
-interfaceDeclaration
-	: annotations? interfaceModifier* INTERFACE Identifier worldParameters typeParameters? extendsInterfaces? interfaceBody
-	;
-
-interfaceModifier
-	:	'public'
-	|	'protected'
-	|	'private'
-	|	'abstract'
-	|	'static'
-	;
-
 enumDeclaration
 	: annotations? classModifier* ENUM Identifier AT worldParameter enumBody
-	;
-
-extendsInterfaces
-	: EXTENDS interfaceTypeList
-	;
-
-interfaceBody
-	: LBRACE interfaceMethodDeclaration* RBRACE
 	;
 
 enumBody
@@ -311,6 +287,30 @@ enumConstant
 	:	Identifier
 	;
 
+/*
+ * Productions from §9 (Interfaces)
+ */
+
+interfaceDeclaration
+	: annotations? interfaceModifier* INTERFACE Identifier worldParameters typeParameters? extendsInterfaces? interfaceBody
+	;
+
+interfaceModifier
+	:	'public'
+	|	'protected'
+	|	'private'
+	|	'abstract'
+	|	'static'
+	;
+
+extendsInterfaces
+	: EXTENDS interfaceTypeList
+	;
+
+interfaceBody
+	: LBRACE interfaceMethodDeclaration* RBRACE
+	;
+
 interfaceMethodDeclaration
 	: annotations? interfaceMethodModifier* methodHeader SEMI
 	;
@@ -321,6 +321,14 @@ interfaceMethodModifier
 	|	'abstract'
 //	|	'default'
 //	|	'static'
+	;
+
+annotations
+	: AT Identifier ( LPAREN annotationValues RPAREN )? annotations?
+	;
+
+annotationValues
+ 	: Identifier ASSIGN literal ( COMMA annotationValues )?
 	;
 
 /*
@@ -433,6 +441,10 @@ methodInvocation
 staticGenericAccess
 	: Identifier worldArguments typeArguments?
 	;
+
+/*
+ * Productions from §15 (Expressions)
+ */
 
 primary
 	:	literal AT worldArgument

--- a/choral/src/main/antlr4/Choral.g4
+++ b/choral/src/main/antlr4/Choral.g4
@@ -324,7 +324,7 @@ interfaceMethodModifier
 	;
 
 annotation
-	: AT Identifier ( LPAREN annotationValues RPAREN )?
+	: AT Identifier ( LPAREN ( literal | annotationValues ) RPAREN )?
 	;
 
 annotationValues

--- a/choral/src/main/java/choral/ast/body/Annotation.java
+++ b/choral/src/main/java/choral/ast/body/Annotation.java
@@ -32,16 +32,16 @@ import java.util.Map;
 public class Annotation extends Node {
 
 	private final Name name;
-	private final Map< Name, LiteralExpression< String > > values;
+	private final Map< Name, LiteralExpression > values;
 
-	public Annotation( Name name, Map< Name, LiteralExpression< String > > values ) {
+	public Annotation( Name name, Map< Name, LiteralExpression > values ) {
 		this.name = name;
 		this.values = values;
 	}
 
 
 	public Annotation(
-			Name name, Map< Name, LiteralExpression< String > > values, final Position position
+			Name name, Map< Name, LiteralExpression > values, final Position position
 	) {
 		super( position );
 		this.name = name;
@@ -52,7 +52,7 @@ public class Annotation extends Node {
 		return name;
 	}
 
-	public Map< Name, LiteralExpression< String > > getValues() {
+	public Map< Name, LiteralExpression > getValues() {
 		return values;
 	}
 

--- a/choral/src/main/java/choral/compiler/AstOptimizer.java
+++ b/choral/src/main/java/choral/compiler/AstOptimizer.java
@@ -180,7 +180,8 @@ public class AstOptimizer implements ChoralVisitor {
 			ChoralParser.AnnotationValuesContext avc
 	) {
 		debugInfo();
-		Map< Name, LiteralExpression > vm = Collections.singletonMap(
+		Map< Name, LiteralExpression > vm = new HashMap<>();
+		vm.put(
 				getName( avc.Identifier() ),
 				visitLiteral( avc.literal(), null )
 		);

--- a/choral/src/main/java/choral/compiler/AstOptimizer.java
+++ b/choral/src/main/java/choral/compiler/AstOptimizer.java
@@ -154,21 +154,15 @@ public class AstOptimizer implements ChoralVisitor {
 	}
 
 	@Override
-	public List< Annotation > visitAnnotations( ChoralParser.AnnotationsContext ac ) {
+	public Annotation visitAnnotation( ChoralParser.AnnotationContext ac ) {
 		debugInfo();
-		List< Annotation > al = new ArrayList<>();
-		al.add(
-				new Annotation(
-						getName( ac.Identifier() ),
-						ifPresent( ac.annotationValues() ).applyOrElse( this::visitAnnotationValues,
-								Collections::emptyMap ),
-						getPosition( ac )
-				)
+
+		return new Annotation(
+				getName( ac.Identifier() ),
+				ifPresent( ac.annotationValues() ).applyOrElse( this::visitAnnotationValues,
+						Collections::emptyMap ),
+				getPosition( ac )
 		);
-		if( isPresent( ac.annotations() ) ) {
-			al.addAll( visitAnnotations( ac.annotations() ) );
-		}
-		return al;
 	}
 
 	@Override
@@ -176,9 +170,7 @@ public class AstOptimizer implements ChoralVisitor {
 			ChoralParser.AnnotationValuesContext avc
 	) {
 		debugInfo();
-		Map< Name, LiteralExpression< String > > vm = new HashMap<>();
-		vm.put( getName( avc.Identifier() ),
-				visitLiteral( avc.literal(), null ) );
+		Map< Name, LiteralExpression< String > > vm = Collections.singletonMap( getName( avc.Identifier() ), visitLiteral( avc.literal(), null ) );
 		if( isPresent( avc.annotationValues() ) ) {
 			vm.putAll( visitAnnotationValues( avc.annotationValues() ) );
 		}
@@ -231,8 +223,7 @@ public class AstOptimizer implements ChoralVisitor {
 				headlessClass.fields(),
 				headlessClass.methods(),
 				headlessClass.constructors(),
-				ifPresent( cls.annotations() ).applyOrElse( this::visitAnnotations,
-						Collections::emptyList ),
+				cls.annotation().stream().map( this::visitAnnotation ).collect( Collectors.toList() ),
 				modifiers,
 				getPosition( cls )
 		);
@@ -281,8 +272,7 @@ public class AstOptimizer implements ChoralVisitor {
 				typeParameters,
 				superTypes,
 				methods,
-				ifPresent( id.annotations() ).applyOrElse( this::visitAnnotations,
-						Collections::emptyList ),
+				id.annotation().stream().map( this::visitAnnotation ).collect( Collectors.toList() ),
 				modifiers,
 				getPosition( id )
 		);
@@ -316,8 +306,7 @@ public class AstOptimizer implements ChoralVisitor {
 				name,
 				visitWorldParameter( ed.worldParameter() ),
 				visitEnumBody( ed.enumBody() ),
-				ifPresent( ed.annotations() ).applyOrElse( this::visitAnnotations,
-						Collections::emptyList ),
+				ed.annotation().stream().map( this::visitAnnotation ).collect( Collectors.toList() ),
 				modifiers,
 				getPosition( ed )
 		);
@@ -606,8 +595,7 @@ public class AstOptimizer implements ChoralVisitor {
 		return new ClassMethodDefinition(
 				visitMethodHeader( md.methodHeader() ),
 				visitMethodBody( md.methodBody() ).orElse( null ),
-				ifPresent( md.annotations() ).applyOrElse( this::visitAnnotations,
-						Collections::emptyList ),
+				md.annotation().stream().map( this::visitAnnotation ).collect( Collectors.toList() ),
 				modifiers,
 				getPosition( md )
 		);
@@ -762,8 +750,7 @@ public class AstOptimizer implements ChoralVisitor {
 
 		return new InterfaceMethodDefinition(
 				visitMethodHeader( imd.methodHeader() ),
-				ifPresent( imd.annotations() ).applyOrElse( this::visitAnnotations,
-						Collections::emptyList ),
+				imd.annotation().stream().map( this::visitAnnotation ).collect( Collectors.toList() ),
 				modifiers,
 				getPosition( imd )
 		);

--- a/choral/src/main/java/choral/compiler/AstOptimizer.java
+++ b/choral/src/main/java/choral/compiler/AstOptimizer.java
@@ -166,11 +166,11 @@ public class AstOptimizer implements ChoralVisitor {
 	}
 
 	@Override
-	public Map< Name, LiteralExpression< String > > visitAnnotationValues(
+	public Map< Name, LiteralExpression > visitAnnotationValues(
 			ChoralParser.AnnotationValuesContext avc
 	) {
 		debugInfo();
-		Map< Name, LiteralExpression< String > > vm = Collections.singletonMap( getName( avc.Identifier() ), visitLiteral( avc.literal(), null ) );
+		Map< Name, LiteralExpression > vm = Collections.singletonMap( getName( avc.Identifier() ), visitLiteral( avc.literal(), null ) );
 		if( isPresent( avc.annotationValues() ) ) {
 			vm.putAll( visitAnnotationValues( avc.annotationValues() ) );
 		}

--- a/choral/src/main/java/choral/compiler/Compiler.java
+++ b/choral/src/main/java/choral/compiler/Compiler.java
@@ -456,7 +456,7 @@ public class Compiler {
 			Node node, String name, String role, List< ImportDeclaration > imports
 	) {
 		imports.add( new ImportDeclaration( "choral.annotations.Choreography", null ) );
-		Map< Name, LiteralExpression< String > > values = new HashMap<>();
+		Map< Name, LiteralExpression > values = new HashMap<>();
 		values.put( new Name( "name" ),
 				new LiteralExpression.StringLiteralExpression( escapeString( name ), null ) );
 		values.put( new Name( "role" ),

--- a/tests/choral/Annotations/ValidAnnotationPositions.ch
+++ b/tests/choral/Annotations/ValidAnnotationPositions.ch
@@ -13,8 +13,8 @@ class BaseClass@A {
 }
 
 @Deprecated(since="4.2")
-@WithDefaultIntVal(23)
-@WithBool(is_used=true)
+@WithDefaultVal(23)
+@WithMultipleValues(name="Test", age=25, is_developer=true)
 class AnnotationTest@A extends BaseClass@A implements I@A {
 
     public String@A strField;

--- a/tests/choral/Annotations/ValidAnnotationPositions.ch
+++ b/tests/choral/Annotations/ValidAnnotationPositions.ch
@@ -1,0 +1,32 @@
+@AnnotatedInterface
+interface I@A {}
+
+@AnnotatedEnum
+enum Time@A {
+    DAY, NIGHT
+}
+
+@AnnotatedClass
+class BaseClass@A {
+    @AnnotatedMethod
+    void baseMethod(String@A param) { }
+}
+
+@Deprecated(since="4.2")
+@WithDefaultIntVal(23)
+@WithBool(is_used=true)
+class AnnotationTest@A extends BaseClass@A implements I@A {
+
+    public String@A strField;
+    public Time@A enumField;
+
+    AnnotationTest() {
+        strField = "test"@A;
+        enumField = Time@A.DAY;
+    }
+
+    @Override
+    void baseMethod(String@A param) {
+        Integer@A tmp = 4@A;
+    }
+}


### PR DESCRIPTION
Slight improvements to annotations:

- Grammar rule is changed to simplify handling of annotations as lists instead of having to deal with them recursively. Now used as `annotation*` instead of `annotations?`
- Allow all literal values in annotations, not just strings
- Add `@Annotation("test")` as syntactic sugar for `@Annotation(value="test")`, so name can be omitted for annotations with the single attribute `value()` (as in Java).
- Add test to check valid annotation positions and values are projected correctly

Unrelated minor improvement: the grammar had header comments referencing the corresponding part of the Java specification. Some of these were missing and a few rules were placed under a different header. This has been fixed.