### PR TITLE
Fix projection bug for multiple bounds

### DIFF
--- a/choral/src/main/java/choral/ast/visitors/PrettyPrinterVisitor.java
+++ b/choral/src/main/java/choral/ast/visitors/PrettyPrinterVisitor.java
@@ -523,7 +523,7 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 		if( !n.upperBound().isEmpty() ) {
 			s.append( ' ' ).append( EXTENDS ).append( ' ' ).append(
 					n.upperBound().stream().map( this::visit ).collect(
-							Collectors.joining( SPACED_COMMA ) )
+							Collectors.joining( AMPERSAND ) )
 			);
 		}
 		return s.toString();

--- a/choral/src/main/java/choral/compiler/JavaCompiler.java
+++ b/choral/src/main/java/choral/compiler/JavaCompiler.java
@@ -53,6 +53,7 @@ public class JavaCompiler extends PrettyPrinterVisitor {
 	private static final String COMMA = ",";
 	private static final String SPACED_COMMA = COMMA + " ";
 	private static final String SEMICOLON = ";";
+	private static final String AMPERSAND = " & ";
 	private static final String IMPLEMENTS = "implements";
 	private static final String EXTENDS = "extends";
 	private static final String PACKAGE = "package";
@@ -236,7 +237,7 @@ public class JavaCompiler extends PrettyPrinterVisitor {
 		if( !n.upperBound().isEmpty() ) {
 			s.append( ' ' ).append( EXTENDS ).append( ' ' ).append(
 					n.upperBound().stream().map( this::visit ).collect(
-							Collectors.joining( SPACED_COMMA ) )
+							Collectors.joining( AMPERSAND ) )
 			);
 		}
 		return s.toString();


### PR DESCRIPTION
This fixes a syntax error when printing and projecting a formal type parameter with multiple bounds. Currently, they get joined with commas, so an interface such as
```java
interface MyInterface@A< T@A, R@A extends IA@A & IB@A > { }
```
projects to
```java
interface MyInterface< T, R extends IA, IB > { }
```
making `IB` another generic rather than an additional bound of `R`. Projection should be
```java
interface MyInterface< T, R extends IA & IB > { }
```

In `PrettyPrinterVisitor`, there is already the utility function `public String visit( FormalTypeParameter n, String inheritance )`, which joins the bounds with ampersands. But using the pretty printer before this fix has the same issue of joining by commas instead of ampersands, so the function seems to not be used (and I'm not sure why it's even there?)