### PR TITLE
Build an executable jar with all of the dependencies

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -64,6 +64,25 @@
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>make-uberjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifest>
+                                    <mainClass>choral.Choral</mainClass>
+                                </manifest>
+                            </archive>
+                            <finalName>choral-v${choral.version}-standalone</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
I've added a second execution of maven-assembly-plugin's `single` goal that builds an "uberjar" with all of the dependencies. The jar is also made executable so that it's very easy to run, without having to specify the main class explicitly.

It seems that the "best practice" way of generating an uberjar these days is using maven-shade-plugin which is capable of "shading" ("renaming") dependencies with clashing resources, etc., but I didn't want to introduce a new dependency right away when this seems to work fine and uses the plugin that we already have.