### PR TITLE
Add CI Pipeline and automated unit tests

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -31,10 +31,12 @@ jobs:
     - name: Unit Tests
       run: mvn test --file pom.xml
 
-    - name: Upload artefacts
+    - name: Upload Release Artefacts
       uses: softprops/action-gh-release@v2
       with:
         files: dist/target/choral-*.zip
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,9 +3,6 @@
 
 name: Maven Package
 
-permissions:
-  contents: write
-
 on:
   release:
     types: [created]
@@ -34,12 +31,13 @@ jobs:
     - name: Unit Tests
       run: mvn test --file pom.xml
 
-    - name: Upload Release Artefacts
-      uses: softprops/action-gh-release@v2
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
       with:
-        files: dist/target/choral-*.zip
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        name: choral-release
+        path: |
+          dist/target/choral-*.zip
+          dist/target/choral-standalone.jar
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -31,6 +31,11 @@ jobs:
     - name: Unit Tests
       run: mvn test --file pom.xml
 
+    - name: Upload artefacts
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/target/choral-*.zip
+
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,6 +3,9 @@
 
 name: Maven Package
 
+permissions:
+  contents: write
+
 on:
   release:
     types: [created]

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,37 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Unit Tests
+      run: mvn test --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -1,0 +1,37 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: Unit Tests
+      run: mvn test --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -31,7 +31,3 @@ jobs:
       run: mvn -B package --file pom.xml
     - name: Unit Tests
       run: mvn test --file pom.xml
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/pom.xml
+++ b/pom.xml
@@ -23,4 +23,11 @@
         <module>tests</module>
     </modules>
 
+    <distributionManagement>
+        <repository>
+        <id>github</id>
+        <name>GitHub Packages</name>
+        <url>https://maven.pkg.github.com/viktorstrate/choral</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <repository>
         <id>github</id>
         <name>GitHub Packages</name>
-        <url>https://maven.pkg.github.com/viktorstrate/choral</url>
+        <url>https://maven.pkg.github.com/choral-lang/choral</url>
         </repository>
     </distributionManagement>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -54,5 +54,21 @@
 			<artifactId>kryo</artifactId>
 			<version>5.3.0</version>
 		</dependency>
+		<dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.8.2</version>
+        <scope>test</scope>
+    </dependency>
 	</dependencies>
+
+	<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.22.2</version>
+        </plugin>
+    </plugins>
+	</build>
 </project>

--- a/tests/src/test/java/choral/ChoralUnitTests.java
+++ b/tests/src/test/java/choral/ChoralUnitTests.java
@@ -1,0 +1,26 @@
+package choral;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import choral.choralUnit.ChoralUnit;
+
+public class ChoralUnitTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // "DistAuthTest", // disabled since TCPChannels fails
+            "VitalsStreamingTest",
+            "MergesortTest",
+            "QuicksortTest",
+            "KaratsubaTest"
+    })
+    public void unitTests(String name) {
+        assertDoesNotThrow(() -> {
+            ChoralUnit.main(new String[] { name });
+        });
+    }
+
+}


### PR DESCRIPTION
This pull request configures the repository to run automatic unit tests on each pull-request.
JUnit5 has been added to `tests/` which is used to automate running the `ChoralUnit` unit tests taken from [here](https://github.com/choral-lang/choral/blob/master/tests/src/main/java/choral/examples/TestChoralUnit.java).

Another Github Action is added which will automatically publish a new version of the library to the Github Packages Maven repository whenever a new Release / Tag is created.

Everything has been tested on my own fork.