### PR TITLE
Fix classlifter nested generics and package-private members

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21' ]
+        java: [ '17', '21', '23', '25' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/choral/src/main/java/choral/compiler/typer/ClassLifter.java
+++ b/choral/src/main/java/choral/compiler/typer/ClassLifter.java
@@ -508,17 +508,7 @@ public class ClassLifter {
 			java.lang.reflect.Type[] typeArgs = paramType.getActualTypeArguments();
 
 			for( java.lang.reflect.Type typeArg : typeArgs ) {
-				// Check for wildcards
-				if( typeArg instanceof java.lang.reflect.WildcardType ) {
-					throw LiftException.wildcard();
-				}
-				GroundDataTypeOrVoid liftedTypeArgument = liftType( typeArg, scope );
-				if(liftedTypeArgument instanceof GroundReferenceType liftedHigherReferenceType){
-					liftedTypeArguments.add( liftedHigherReferenceType.typeConstructor() );
-				} else{
-					throw new RuntimeException("Type argument returned isn't a GroundReferenceType: " 
-					+ "'" + typeArg.getTypeName() + "'");
-				}
+				liftedTypeArguments.add( liftTypeArg( typeArg, scope ) );
 			}
 
 			String typeName = rawClass.getCanonicalName();
@@ -541,6 +531,44 @@ public class ClassLifter {
 		else {
 			throw LiftException.exoticType( type );
 		}
+	}
+
+	/**
+	 * A version of liftType for lifting type arguments. In Choral, type args have to be higher 
+	 * reference types, i.e. reference types that haven't been applied to worlds yet. Whereas
+	 * liftType will lift {@code List<Number>} into the ground type {@code List@A<Number>}, 
+	 * liftTypeArg will lift it into a higher reference type {@code List<Number>}.
+	 */
+	private HigherReferenceType liftTypeArg(
+			java.lang.reflect.Type type, Scope scope
+	) throws LiftException {
+		if( type instanceof java.lang.Class< ? > clazz ) {
+			if( clazz.isArray() ) throw LiftException.array();
+			if( clazz.isMemberClass() ) throw LiftException.innerClass();
+			if( clazz.isPrimitive() ) {
+				throw LiftException.castFailed( type.getTypeName(), "reference type" );
+			}
+			// Whereas liftType applies the type to world args, liftTypeArg does not
+			return liftClassOrInterface( clazz.getCanonicalName() );
+		}
+		if( type instanceof java.lang.reflect.ParameterizedType paramType ) {
+			java.lang.Class< ? > rawClass = (java.lang.Class< ? >) paramType.getRawType();
+			if( rawClass.isMemberClass() ) throw LiftException.innerClass();
+
+			List< HigherReferenceType > typeArguments = new ArrayList<>();
+			for( java.lang.reflect.Type typeArgument : paramType.getActualTypeArguments() ) {
+				typeArguments.add( liftTypeArg( typeArgument, scope ) );
+			}
+			// Supply type args but not world args
+			return liftClassOrInterface( rawClass.getCanonicalName() )
+					.partiallyApplyTo( typeArguments );
+		}
+		if( type instanceof java.lang.reflect.TypeVariable< ? > typeVariable ) {
+			return scope.assertLookupTypeParameter( typeVariable.getName() );
+		}
+		if( type instanceof java.lang.reflect.GenericArrayType ) throw LiftException.array();
+		if( type instanceof java.lang.reflect.WildcardType ) throw LiftException.wildcard();
+		throw LiftException.exoticType( type );
 	}
 
 	private GroundClass liftClass(java.lang.reflect.Type type, Scope scope) throws LiftException {

--- a/choral/src/main/java/choral/compiler/typer/ClassLifter.java
+++ b/choral/src/main/java/choral/compiler/typer/ClassLifter.java
@@ -294,7 +294,8 @@ public class ClassLifter {
 			ClassOrInterfaceInstanceScope scope
 	) {
 		for(Method method : clazz.getDeclaredMethods()){
-			if(Modifier.isPrivate(method.getModifiers())) continue;
+			int modifiers = method.getModifiers();
+			if(!Modifier.isPublic(modifiers) && !Modifier.isProtected(modifiers)) continue;
 			if(method.isBridge()) continue;
 			Member.HigherMethod higherMethod;
 			try{
@@ -328,10 +329,10 @@ public class ClassLifter {
 			Field[] fields, ClassOrInterfaceInstanceScope scope, HigherClassOrInterface higherClass
 	) {
 		for( Field field : fields ){
-			// private fields will never be accessed
-			if(Modifier.isPrivate(field.getModifiers())) continue;
+			int modifiers = field.getModifiers();
+			if(!Modifier.isPublic(modifiers) && !Modifier.isProtected(modifiers)) continue;
 
-			EnumSet<choral.types.Modifier> fieldModifiers = parseModifiers( field.getModifiers());
+			EnumSet<choral.types.Modifier> fieldModifiers = parseModifiers( modifiers);
 			GroundDataType fieldType;
 			try{
 				fieldType = liftDataType(field.getGenericType(), scope );

--- a/choral/src/test/java/ClassLifterTest.java
+++ b/choral/src/test/java/ClassLifterTest.java
@@ -18,7 +18,7 @@ import choral.utils.VerbosityLevel;
 public class ClassLifterTest {
 
 	@Test
-	public void helloWorldTest() throws IOException {
+	public void stdlibTest() throws IOException {
 		Universe universe = new Universe();
 		TaskQueue taskQueue = new TaskQueue();
 		TyperOptions opts = new TyperOptions( VerbosityLevel.WARNINGS );
@@ -53,5 +53,18 @@ public class ClassLifterTest {
 						() -> "Expected ClassLifter to find " + typeName )
 		) );
 		assertFalse( classLifter.lookup( "supplement.DoesNotExist", null ).isPresent() );
+	}
+
+	@Test
+	public void nestedGenericsTest() throws IOException {
+		Universe universe = new Universe();
+		TaskQueue taskQueue = new TaskQueue();
+		TyperOptions opts = new TyperOptions( VerbosityLevel.WARNINGS );
+
+		Typer.annotate( List.of(), HeaderLoader.loadStandardProfile().toList(), universe, opts );
+
+		ClassLifter classLifter = new ClassLifter( universe, taskQueue, opts );
+		assertTrue( classLifter.lookup( "supplement.LiftedConcrete", null ).isPresent() );
+		taskQueue.process();
 	}
 }

--- a/choral/src/test/java/supplement/LiftedBase.java
+++ b/choral/src/test/java/supplement/LiftedBase.java
@@ -1,0 +1,10 @@
+package supplement;
+
+import java.util.List;
+
+public abstract class LiftedBase implements LiftedFunction<String, Number, RuntimeException> {
+	@Override
+	public RuntimeException apply(String input, List<Number> nested) {
+		return new RuntimeException();
+	}
+}

--- a/choral/src/test/java/supplement/LiftedConcrete.java
+++ b/choral/src/test/java/supplement/LiftedConcrete.java
@@ -1,0 +1,4 @@
+package supplement;
+
+public class LiftedConcrete extends LiftedBase {
+}

--- a/choral/src/test/java/supplement/LiftedFunction.java
+++ b/choral/src/test/java/supplement/LiftedFunction.java
@@ -1,0 +1,7 @@
+package supplement;
+
+import java.util.List;
+
+public interface LiftedFunction<T, U, R> {
+	R apply(T input, List<U> nested);
+}


### PR DESCRIPTION
- Fix bug where nested generics weren't lifted properly
- Add jdk 23 and 25 to CI
- Prevent classlifter exploring package-private fields and methods