### PR TITLE
Expand CI coverage and smoke-test CLI

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -14,12 +14,16 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-latest, windows-latest ]
         java: [ '17', '21', '23', '25' ]
 
     steps:
@@ -30,7 +34,7 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
-      run: mvn -B package -DskipTests --file pom.xml
-    - name: Unit Tests
-      run: mvn -B test --file pom.xml
+    - name: Build and test with Maven
+      run: mvn --batch-mode --no-transfer-progress verify --file pom.xml
+    - name: Smoke test the Choral launcher
+      run: java -jar dist/target/choral-standalone.jar check tests/src/main/choral/MustPass/Misc/HelloRoles.ch

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ target/
 .DS_Store
 .factorypath
 .flattened-pom.xml
-# ANTLR generated files
 /choral/src/main/java/choral/grammar/
 /build
 /choral/src/main/antlr4/
@@ -22,3 +21,4 @@ CLAUDE.md
 AGENTS.md
 /tests/bin
 /tests/projectedOutput
+mise.toml


### PR DESCRIPTION
- Constrain permissions for ci
- Add windows to ci
- Smoke-test the choral-standalone.jar launcher
- Add mise to gitignore