### PR TITLE
Local type inference

### DIFF
--- a/Choral_code_style.xml
+++ b/Choral_code_style.xml
@@ -5,7 +5,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 		<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
 		<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
-		<setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="1"/>
 		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
 		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
 		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>

--- a/choral/src/main/antlr4/Choral.g4
+++ b/choral/src/main/antlr4/Choral.g4
@@ -350,7 +350,10 @@ blockStatement
 	;
 
 localVariableDeclaration
-	: annotation* variableModifier* referenceType variableDeclarator ( COMMA variableDeclarator )* SEMI
+	: annotation* variableModifier*
+	  ( referenceType variableDeclarator ( COMMA variableDeclarator )*
+	  | VAR variableDeclarator
+	  ) SEMI
 	;
 
 variableModifier
@@ -614,6 +617,7 @@ TRY			: 'try';
 CATCH		: 'catch';
 NULL		: 'null';
 VOID 		: 'void';
+VAR         : 'var';
 AMPERSAND	: '&';
 
 

--- a/choral/src/main/java/choral/ast/body/VariableDeclaration.java
+++ b/choral/src/main/java/choral/ast/body/VariableDeclaration.java
@@ -50,7 +50,8 @@ public class VariableDeclaration extends Node {
 			final AssignExpression initializer,
 			final Position position
 	) {
-		this( name, type, annotations, initializer, EnumSet.noneOf( VariableModifier.class ), position );
+		this( name, type, annotations, initializer, EnumSet.noneOf( VariableModifier.class ),
+				position );
 	}
 
 	public VariableDeclaration(
@@ -60,9 +61,10 @@ public class VariableDeclaration extends Node {
 			final AssignExpression initializer,
 			final Position position
 	) {
-		this( name, type, annotations, initializer, EnumSet.noneOf( VariableModifier.class ), position );
+		this( name, type, annotations, initializer, EnumSet.noneOf( VariableModifier.class ),
+				position );
 	}
-	
+
 
 	public VariableDeclaration(
 			final Name name,
@@ -71,7 +73,7 @@ public class VariableDeclaration extends Node {
 			final AssignExpression initializer,
 			final EnumSet< VariableModifier > modifiers
 	) {
-	    this(name, Optional.of(type), annotations, initializer, modifiers, null);
+		this( name, Optional.of( type ), annotations, initializer, modifiers, null );
 	}
 
 	public VariableDeclaration(
@@ -81,10 +83,9 @@ public class VariableDeclaration extends Node {
 			final AssignExpression initializer,
 			final EnumSet< VariableModifier > modifiers
 	) {
-	    this(name, type, annotations, initializer, modifiers, null);
+		this( name, type, annotations, initializer, modifiers, null );
 	}
 
-	
 
 	public VariableDeclaration(
 			final Name name,
@@ -94,7 +95,7 @@ public class VariableDeclaration extends Node {
 			final EnumSet< VariableModifier > modifiers,
 			final Position position
 	) {
-    	this(name, Optional.of( type ), annotations, initializer, modifiers, position);
+		this( name, Optional.of( type ), annotations, initializer, modifiers, position );
 	}
 
 	public VariableDeclaration(
@@ -112,7 +113,7 @@ public class VariableDeclaration extends Node {
 		this.initializer = initializer;
 		this.modifiers = copyModifiers( modifiers );
 	}
-	
+
 
 	public Name name() {
 		return name;
@@ -153,10 +154,10 @@ public class VariableDeclaration extends Node {
 	}
 
 	private static EnumSet< VariableModifier > copyModifiers(
-			EnumSet< VariableModifier > modifiers ) {
-		return modifiers.isEmpty()
-				? EnumSet.noneOf( VariableModifier.class )
-				: EnumSet.copyOf( modifiers );
+			EnumSet< VariableModifier > modifiers
+	) {
+		return modifiers.isEmpty() ? EnumSet.noneOf( VariableModifier.class ) :
+				EnumSet.copyOf( modifiers );
 	}
 
 	@Override

--- a/choral/src/main/java/choral/ast/body/VariableDeclaration.java
+++ b/choral/src/main/java/choral/ast/body/VariableDeclaration.java
@@ -38,7 +38,7 @@ import static choral.ast.body.VariableModifier.FINAL;
 public class VariableDeclaration extends Node {
 
 	private final Name name;
-	private final TypeExpression type;
+	private final Optional< TypeExpression > type;
 	private final List< Annotation > annotations;
 	private final AssignExpression initializer;
 	private final EnumSet< VariableModifier > modifiers;
@@ -55,21 +55,51 @@ public class VariableDeclaration extends Node {
 
 	public VariableDeclaration(
 			final Name name,
+			final Optional< TypeExpression > type,
+			final List< Annotation > annotations,
+			final AssignExpression initializer,
+			final Position position
+	) {
+		this( name, type, annotations, initializer, EnumSet.noneOf( VariableModifier.class ), position );
+	}
+	
+
+	public VariableDeclaration(
+			final Name name,
 			final TypeExpression type,
 			final List< Annotation > annotations,
 			final AssignExpression initializer,
 			final EnumSet< VariableModifier > modifiers
 	) {
-		this.name = name;
-		this.type = type;
-		this.annotations = annotations;
-		this.initializer = initializer;
-		this.modifiers = copyModifiers( modifiers );
+	    this(name, Optional.of(type), annotations, initializer, modifiers, null);
 	}
 
 	public VariableDeclaration(
 			final Name name,
+			final Optional< TypeExpression > type,
+			final List< Annotation > annotations,
+			final AssignExpression initializer,
+			final EnumSet< VariableModifier > modifiers
+	) {
+	    this(name, type, annotations, initializer, modifiers, null);
+	}
+
+	
+
+	public VariableDeclaration(
+			final Name name,
 			final TypeExpression type,
+			final List< Annotation > annotations,
+			final AssignExpression initializer,
+			final EnumSet< VariableModifier > modifiers,
+			final Position position
+	) {
+    	this(name, Optional.of( type ), annotations, initializer, modifiers, position);
+	}
+
+	public VariableDeclaration(
+			final Name name,
+			final Optional< TypeExpression > type,
 			final List< Annotation > annotations,
 			final AssignExpression initializer,
 			final EnumSet< VariableModifier > modifiers,
@@ -82,13 +112,18 @@ public class VariableDeclaration extends Node {
 		this.initializer = initializer;
 		this.modifiers = copyModifiers( modifiers );
 	}
+	
 
 	public Name name() {
 		return name;
 	}
 
-	public TypeExpression type() {
+	public Optional< TypeExpression > type() {
 		return type;
+	}
+
+	public TypeExpression inferredTypeExpression() {
+		return type.orElseGet( () -> typeAnnotation().get().reify() );
 	}
 
 	public List< Annotation > annotations() {

--- a/choral/src/main/java/choral/ast/visitors/ChoralVisitor.java
+++ b/choral/src/main/java/choral/ast/visitors/ChoralVisitor.java
@@ -99,12 +99,13 @@ public class ChoralVisitor implements ChoralVisitorInterface< Node > {
 	public Node visit( SwitchStatement n ) {
 		return new SwitchStatement(
 				safeVisit( n.guard() ),
-				n.cases().entrySet().stream().map( e ->
-						new AbstractMap.SimpleEntry< SwitchArgument< ? >, Statement >(
+				n.cases().entrySet().stream()
+						.map( e -> new AbstractMap.SimpleEntry< SwitchArgument< ? >, Statement >(
 								safeVisit( e.getKey() ), safeVisit( e.getValue() )
 						) {
-						} ).collect( Streams.toLinkedHashMap( Map.Entry::getKey, Map.Entry::getValue )
-				),
+						} )
+						.collect( Streams.toLinkedHashMap( Map.Entry::getKey, Map.Entry::getValue )
+						),
 				safeVisit( n.continuation() ),
 				n.position()
 		);
@@ -130,9 +131,10 @@ public class ChoralVisitor implements ChoralVisitorInterface< Node > {
 	public Node visit( TryCatchStatement n ) {
 		return new TryCatchStatement(
 				safeVisit( n.body() ),
-				n.catches().stream().map( c ->
-						new Pair<>( safeVisit( c.left() ), safeVisit( c.right() ) )
-				).collect( Collectors.toList() ), safeVisit( n.continuation() ),
+				n.catches().stream()
+						.map( c -> new Pair<>( safeVisit( c.left() ), safeVisit( c.right() ) ) )
+						.collect( Collectors.toList() ),
+				safeVisit( n.continuation() ),
 				n.position()
 		);
 	}

--- a/choral/src/main/java/choral/ast/visitors/ChoralVisitor.java
+++ b/choral/src/main/java/choral/ast/visitors/ChoralVisitor.java
@@ -453,7 +453,7 @@ public class ChoralVisitor implements ChoralVisitorInterface< Node > {
 	public Node visit( VariableDeclaration n ) {
 		return new VariableDeclaration(
 				safeVisit( n.name() ),
-				safeVisit( n.type() ),
+				n.type().map( this::safeVisit ),
 				visitAndCollect( n.annotations() ),
 				safeVisit( n.initializer().orElse( null ) ),
 				n.modifiers(),

--- a/choral/src/main/java/choral/ast/visitors/PrettyPrinterVisitor.java
+++ b/choral/src/main/java/choral/ast/visitors/PrettyPrinterVisitor.java
@@ -60,11 +60,13 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 
 	@Override
 	public String visit( CompilationUnit n ) {
-		return ( n.packageDeclaration().isPresent() ? PACKAGE + " " + n.packageDeclaration().get() + SEMICOLON + _2NEWLINE : "" )
-				+ visitAndCollect( n.imports(), SEMICOLON + NEWLINE, SEMICOLON + _2NEWLINE )
-				+ visitAndCollect( n.interfaces(), NEWLINE, NEWLINE )
-				+ visitAndCollect( n.enums(), NEWLINE, NEWLINE )
-				+ visitAndCollect( n.classes(), NEWLINE, NEWLINE );
+		var pkg = ( n.packageDeclaration().isPresent() ?
+				PACKAGE + " " + n.packageDeclaration().get() + SEMICOLON + _2NEWLINE : "" );
+		var imports = visitAndCollect( n.imports(), SEMICOLON + NEWLINE, SEMICOLON + _2NEWLINE );
+		var interfaces = visitAndCollect( n.interfaces(), NEWLINE, NEWLINE );
+		var enums = visitAndCollect( n.enums(), NEWLINE, NEWLINE );
+		var classes = visitAndCollect( n.classes(), NEWLINE, NEWLINE );
+		return pkg + imports + interfaces + enums + classes;
 	}
 
 	@Override
@@ -220,10 +222,10 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 				"$body" + NEWLINE +
 				"}" + NEWLINE + "$catches";
 		m.put( "body", indent( visit( n.body() ) ) );
-		String catches = n.catches().stream().map( e ->
-				"catch ( " + visit( e.left(), " " ) + " ) { " + NEWLINE +
+		String catches = n.catches().stream()
+				.map( e -> "catch ( " + visit( e.left(), " " ) + " ) { " + NEWLINE +
 						indent( visit( e.right() ) ) + NEWLINE + "}"
-		).collect( Collectors.joining( NEWLINE ) );
+				).collect( Collectors.joining( NEWLINE ) );
 		m.put( "catches", catches );
 
 		return Utils.createVelocityTemplate( template )
@@ -261,11 +263,12 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 
 	@Override
 	public String visit( ClassInstantiationExpression n ) {
-		return
-				"new " + ( n.typeArguments().isEmpty() ? "" : "< " + visitAndCollect(
-						n.typeArguments(), SPACED_COMMA ) + " >" ) + visit( n.typeExpression() ) +
-						( n.arguments().isEmpty() ? "()" : "( " + visitAndCollect( n.arguments(),
-								SPACED_COMMA ) + " )" );
+		var typeArgs = n.typeArguments().isEmpty() ? "" :
+				"< " + visitAndCollect( n.typeArguments(), SPACED_COMMA ) + " >";
+		var typeExpr = visit( n.typeExpression() );
+		var args = n.arguments().isEmpty() ? "()" :
+				"( " + visitAndCollect( n.arguments(), SPACED_COMMA ) + " )";
+		return "new " + typeArgs + typeExpr + args;
 	}
 
 	@Override
@@ -300,12 +303,13 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 	 * @param explicitThisReceiver if true, the method call is printed with an explicit "this."
 	 */
 	private String visitMethodCall( MethodCallExpression n, boolean explicitThisReceiver ) {
-		String typeArguments = n.typeArguments().isEmpty() ? "" :
+		var typeArguments = n.typeArguments().isEmpty() ? "" :
 				"< " + visitAndCollect( n.typeArguments(), SPACED_COMMA ) + " >";
-		String receiver = explicitThisReceiver ? "this." : "";
-		return receiver + typeArguments + visit( n.name() )
-				+ ( n.arguments().isEmpty() ? "()" : "( " + visitAndCollect( n.arguments(),
-				SPACED_COMMA ) + " )" );
+		var receiver = explicitThisReceiver ? "this." : "";
+		var name = visit( n.name() );
+		var args = n.arguments().isEmpty() ? "()" :
+				"( " + visitAndCollect( n.arguments(), SPACED_COMMA ) + " )";
+		return receiver + typeArguments + name + args;
 	}
 
 	@Override
@@ -382,11 +386,11 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 		} else {
 			String pattern = null;
 
-			if ( n instanceof SwitchArgument.SwitchArgumentLiteral l ) {
+			if( n instanceof SwitchArgument.SwitchArgumentLiteral l ) {
 				pattern = l.argument().content().toString();
-			} else if ( n instanceof SwitchArgument.SwitchArgumentLabel l ) {
+			} else if( n instanceof SwitchArgument.SwitchArgumentLabel l ) {
 				pattern = l.argument().identifier();
-			} else if ( n instanceof SwitchArgument.SwitchArgumentClassLabel l ) {
+			} else if( n instanceof SwitchArgument.SwitchArgumentClassLabel l ) {
 				Pair< Name, Name > arg = l.argument();
 				pattern = arg.left().identifier() + " " + arg.right().identifier();
 			}
@@ -478,12 +482,11 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 
 	@Override
 	public String visit( MethodSignature n ) {
-		return
-				( n.typeParameters().isEmpty() ? "" : "< " + visitAndCollect( n.typeParameters(),
-						SPACED_COMMA ) + " > " )
-						+ visit( n.returnType() )
-						+ " " + n.name()
-						+ ( n.parameters().isEmpty() ? "()" : "( " + visitAndCollect(
+		return ( n.typeParameters().isEmpty() ? "" : "< " + visitAndCollect( n.typeParameters(),
+				SPACED_COMMA ) + " > " )
+				+ visit( n.returnType() )
+				+ " " + n.name()
+				+ ( n.parameters().isEmpty() ? "()" : "( " + visitAndCollect(
 						n.parameters(), SPACED_COMMA ) + " )" );
 	}
 
@@ -495,17 +498,19 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 		m.put( "signature", visit( n.signature() ) );
 		m.put( "body", indent( visit( n.body() ) ) );
 
-		String template = "${annotations}$modifiers$signature {" + NEWLINE + "$body" + NEWLINE + "}";
+		String template =
+				"${annotations}$modifiers$signature {" + NEWLINE + "$body" + NEWLINE + "}";
 		return Utils.createVelocityTemplate( template ).render( m );
 	}
 
 	@Override
 	public String visit( ConstructorSignature n ) {
-		return ( n.typeParameters().isEmpty() ? "" : "< " + visitAndCollect( n.typeParameters(),
-				SPACED_COMMA ) + " > " ) +
-				n.name() +
-				( n.parameters().isEmpty() ? "()" : "( " + visitAndCollect( n.parameters(),
-						SPACED_COMMA ) + " )" );
+		var typeParams = n.typeParameters().isEmpty() ? "" :
+				"< " + visitAndCollect( n.typeParameters(), SPACED_COMMA ) + " > ";
+		var name = n.name();
+		var params = n.parameters().isEmpty() ? "()" :
+				"( " + visitAndCollect( n.parameters(), SPACED_COMMA ) + " )";
+		return typeParams + name + params;
 	}
 
 	@Override
@@ -516,16 +521,16 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 	public String visit( VariableDeclaration n, String separator ) {
 		return visitAndCollect( n.annotations(), separator, separator )
 				+ ( n.isFinal() ? "final " : "" )
-					+ n.type().map( this::visit ).orElse( "var" ) + " " + visit( n.name() );
+				+ n.type().map( this::visit ).orElse( "var" ) + " " + visit( n.name() );
 	}
 
 	@Override
 	public String visit( TypeExpression n ) {
-		return n.name() +
-				( n.worldArguments().isEmpty() ? "" : "@( " + visitAndCollect( n.worldArguments(),
-						SPACED_COMMA ) + " )" ) +
-				( n.typeArguments().isEmpty() ? "" : "< " + visitAndCollect( n.typeArguments(),
-						SPACED_COMMA ) + " >" );
+		var worlds = n.worldArguments().isEmpty() ? "" :
+				"@( " + visitAndCollect( n.worldArguments(), SPACED_COMMA ) + " )";
+		var typeArgs = n.typeArguments().isEmpty() ? "" :
+				"< " + visitAndCollect( n.typeArguments(), SPACED_COMMA ) + " >";
+		return n.name() + worlds + typeArgs;
 	}
 
 	@Override
@@ -540,14 +545,13 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 
 	@Override
 	public String visit( Annotation n ) {
-		return ANNOTATION
-				+ n.getName().identifier()
-				+ ( n.getValues().isEmpty() ? ""
-				: "( " + n.getValues().entrySet().stream()
-				.map( e -> e.getKey().identifier() + " " + AssignExpression.Operator.ASSIGN.symbol() + " " + visit(
-						e.getValue() ) )
-				.collect( Collectors.joining( SPACED_COMMA ) ) + " )"
-		);
+		var values = n.getValues().isEmpty() ? "" :
+				"( " + n.getValues().entrySet().stream()
+						.map( e -> e.getKey().identifier() + " "
+								+ AssignExpression.Operator.ASSIGN.symbol() + " "
+								+ visit( e.getValue() ) )
+						.collect( Collectors.joining( SPACED_COMMA ) ) + " )";
+		return ANNOTATION + n.getName().identifier() + values;
 	}
 
 	@Override

--- a/choral/src/main/java/choral/ast/visitors/PrettyPrinterVisitor.java
+++ b/choral/src/main/java/choral/ast/visitors/PrettyPrinterVisitor.java
@@ -341,7 +341,7 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 	@Override
 	public String visit( VariableDeclarationStatement n ) {
 		// Visit manually to preserve structure from original code
-		String type = visit( n.variables().get( 0 ).type() );
+		String type = n.variables().get( 0 ).type().map( this::visit ).orElse( "var" );
 		String variables = n.variables().stream().map(
 				v -> visit( v.name() ) + v.initializer().map(
 						e -> ASSIGN + visit( e.value() ) ).orElse( "" )
@@ -515,8 +515,8 @@ public class PrettyPrinterVisitor implements ChoralVisitorInterface< String > {
 
 	public String visit( VariableDeclaration n, String separator ) {
 		return visitAndCollect( n.annotations(), separator, separator )
-				+ ( n.isFinal() ? "final " : "" ) + visit(
-				n.type() ) + " " + visit( n.name() );
+				+ ( n.isFinal() ? "final " : "" )
+					+ n.type().map( this::visit ).orElse( "var" ) + " " + visit( n.name() );
 	}
 
 	@Override

--- a/choral/src/main/java/choral/compiler/AstOptimizer.java
+++ b/choral/src/main/java/choral/compiler/AstOptimizer.java
@@ -896,7 +896,8 @@ public class AstOptimizer implements ChoralVisitor {
 			ChoralParser.LocalVariableDeclarationContext lvd
 	) {
 		debugInfo();
-		TypeExpression type = visitReferenceType( lvd.referenceType() );
+		Optional< TypeExpression > type = Optional.ofNullable( lvd.referenceType() )
+				.map( this::visitReferenceType );
 		List< Annotation > annotations = lvd.annotation().stream().map(
 				this::visitAnnotation ).collect( Collectors.toList() );
 		EnumSet< VariableModifier > modifiers = visitVariableModifiers( lvd.variableModifier() );
@@ -931,13 +932,13 @@ public class AstOptimizer implements ChoralVisitor {
 			ChoralParser.VariableDeclaratorContext vd
 	) {
 		throw new UnsupportedOperationException(
-				"visitVariableDeclarator( ChoralParser.VariableDeclaratorContext vd ) should not be used. Use visitVariableDeclarator( ChoralParser.VariableDeclaratorContext vd, TypeExpression type ) instead"
+				"visitVariableDeclarator( ChoralParser.VariableDeclaratorContext vd ) should not be used. Use visitVariableDeclarator( ChoralParser.VariableDeclaratorContext vd, Optional< TypeExpression > type ) instead"
 		);
 	}
 
 	public VariableDeclaration visitVariableDeclarator(
 			ChoralParser.VariableDeclaratorContext vd,
-			TypeExpression type,
+			Optional< TypeExpression > type,
 			List< Annotation > annotations,
 			EnumSet< VariableModifier > modifiers
 	) {

--- a/choral/src/main/java/choral/compiler/AstOptimizer.java
+++ b/choral/src/main/java/choral/compiler/AstOptimizer.java
@@ -57,7 +57,7 @@ public class AstOptimizer implements ChoralVisitor {
 	private final List< Class > classes;
 	private final List< Enum > enums;
 	private String file = "";
-	private Optional<String> _package = Optional.empty();
+	private Optional< String > _package = Optional.empty();
 	private final Set< String > debugExcludeMethods = new HashSet<>();
 	private boolean debug;
 	private String lastMethod = "";
@@ -104,8 +104,7 @@ public class AstOptimizer implements ChoralVisitor {
 	public String visitQualifiedName( ChoralParser.QualifiedNameContext qn ) {
 		debugInfo();
 		return ifPresent( qn.qualifiedName() ).applyOrElse( q -> visitQualifiedName( q ) + ".",
-				String::new ) +
-				qn.Identifier().getText();
+				String::new ) + qn.Identifier().getText();
 	}
 
 	/* * * * * * WORLDS AND TYPES PARAMETERS * * * * * */
@@ -203,7 +202,8 @@ public class AstOptimizer implements ChoralVisitor {
 			ClassModifier m = visitClassModifier( ctx );
 			if( modifiers.contains( m ) ) {
 				throw new SyntaxException( getPosition( ctx ),
-						"Illegal combination of modifiers '" + m.label + "' and '" + m.label + "'." );
+						"Illegal combination of modifiers '" + m.label + "' and '" + m.label
+								+ "'." );
 			} else {
 				modifiers.add( m );
 			}
@@ -263,7 +263,8 @@ public class AstOptimizer implements ChoralVisitor {
 			InterfaceModifier m = visitInterfaceModifier( ctx );
 			if( modifiers.contains( m ) ) {
 				throw new SyntaxException( getPosition( ctx ),
-						"Illegal combination of modifiers '" + m.label + "' and '" + m.label + "'." );
+						"Illegal combination of modifiers '" + m.label + "' and '" + m.label
+								+ "'." );
 			} else {
 				modifiers.add( m );
 			}
@@ -313,7 +314,8 @@ public class AstOptimizer implements ChoralVisitor {
 			ClassModifier m = visitClassModifier( ctx );
 			if( modifiers.contains( m ) ) {
 				throw new SyntaxException( getPosition( ctx ),
-						"Illegal combination of modifiers '" + m.label + "' and '" + m.label + "'." );
+						"Illegal combination of modifiers '" + m.label + "' and '" + m.label
+								+ "'." );
 			} else {
 				modifiers.add( m );
 			}
@@ -502,8 +504,8 @@ public class AstOptimizer implements ChoralVisitor {
 		debugInfo();
 
 		List< Node > bodyMembers = ifPresent( cb.classBodyDeclaration() ).applyOrElse(
-				el -> el.stream().flatMap(
-								e -> visitClassBodyDeclaration( e ).stream() )
+				el -> el.stream()
+						.flatMap( e -> visitClassBodyDeclaration( e ).stream() )
 						.collect( Collectors.toList() ),
 				Collections::emptyList );
 		List< Field > fields = bodyMembers.stream()
@@ -540,7 +542,7 @@ public class AstOptimizer implements ChoralVisitor {
 		debugInfo();
 		if( cmd.fieldDeclaration() != null ) {
 			return visitFieldDeclaration( cmd.fieldDeclaration() );
-		} else if (cmd.methodDeclaration() != null ) {
+		} else if( cmd.methodDeclaration() != null ) {
 			return Collections.singletonList( visitMethodDeclaration( cmd.methodDeclaration() ) );
 		} else {
 			throw new SyntaxException( getPosition( cmd ),
@@ -558,7 +560,8 @@ public class AstOptimizer implements ChoralVisitor {
 			FieldModifier m = visitFieldModifier( ctx );
 			if( modifiers.contains( m ) ) {
 				throw new SyntaxException( getPosition( ctx ),
-						"Illegal combination of modifiers '" + m.label + "' and '" + m.label + "'." );
+						"Illegal combination of modifiers '" + m.label + "' and '" + m.label
+								+ "'." );
 			} else {
 				modifiers.add( m );
 			}
@@ -612,7 +615,8 @@ public class AstOptimizer implements ChoralVisitor {
 			ClassMethodModifier m = visitMethodModifier( ctx );
 			if( modifiers.contains( m ) ) {
 				throw new SyntaxException( getPosition( ctx ),
-						"Illegal combination of modifiers '" + m.label + "' and '" + m.label + "'." );
+						"Illegal combination of modifiers '" + m.label + "' and '" + m.label
+								+ "'." );
 			} else {
 				modifiers.add( m );
 			}
@@ -681,7 +685,8 @@ public class AstOptimizer implements ChoralVisitor {
 			ConstructorModifier m = visitConstructorModifier( ctx );
 			if( modifiers.contains( m ) ) {
 				throw new SyntaxException( getPosition( ctx ),
-						"Illegal combination of modifiers '" + m.label + "' and '" + m.label + "'." );
+						"Illegal combination of modifiers '" + m.label + "' and '" + m.label
+								+ "'." );
 			} else {
 				modifiers.add( m );
 			}
@@ -732,9 +737,8 @@ public class AstOptimizer implements ChoralVisitor {
 	) {
 		debugInfo();
 		return new Pair<>(
-				( ctx.explicitConstructorInvocation() == null )
-						? null
-						: visitExplicitConstructorInvocation( ctx.explicitConstructorInvocation() ),
+				( ctx.explicitConstructorInvocation() == null ) ? null :
+						visitExplicitConstructorInvocation( ctx.explicitConstructorInvocation() ),
 				visitBlockStatements( ctx.blockStatements() )
 		);
 	}
@@ -776,7 +780,8 @@ public class AstOptimizer implements ChoralVisitor {
 			InterfaceMethodModifier m = visitInterfaceMethodModifier( ctx );
 			if( modifiers.contains( m ) ) {
 				throw new SyntaxException( getPosition( ctx ),
-						"Illegal combination of modifiers '" + m.label + "' and '" + m.label + "'." );
+						"Illegal combination of modifiers '" + m.label + "' and '" + m.label
+								+ "'." );
 			} else {
 				modifiers.add( m );
 			}
@@ -994,9 +999,9 @@ public class AstOptimizer implements ChoralVisitor {
 		debugInfo();
 		return new ExpressionStatement(
 				isPresent( es.statementExpression() ) ?
-						visitStatementExpression( es.statementExpression() )
-						: visitChainedExpression( es.chainedExpression(),
-						visitExpression( es.expression() ) ),
+						visitStatementExpression( es.statementExpression() ) :
+						visitChainedExpression( es.chainedExpression(),
+								visitExpression( es.expression() ) ),
 				null,
 				getPosition( es ) );
 	}
@@ -1085,8 +1090,8 @@ public class AstOptimizer implements ChoralVisitor {
 		debugInfo();
 		Expression e = new ScopedExpression(
 				tosma.superSymbol != null ?
-						new SuperExpression( getPosition( tosma.superSymbol ) )
-						: new ThisExpression( getPosition( tosma.thisSymbol ) ),
+						new SuperExpression( getPosition( tosma.superSymbol ) ) :
+						new ThisExpression( getPosition( tosma.thisSymbol ) ),
 				visitMethodInvocation( tosma.methodInvocation() )
 		);
 		e.setPosition( getPosition( tosma ) );
@@ -1320,12 +1325,10 @@ public class AstOptimizer implements ChoralVisitor {
 	public ReturnStatement visitReturnStatement( ChoralParser.ReturnStatementContext rs ) {
 		debugInfo();
 		return new ReturnStatement(
-				isPresent( rs.chainedExpression() )
-						? visitChainedExpression( rs.chainedExpression(),
-						visitExpression( rs.expression() ) )
-						: isPresent( rs.expression() ) ? visitExpression( rs.expression() )
-						: null
-				,
+				isPresent( rs.chainedExpression() ) ?
+						visitChainedExpression( rs.chainedExpression(),
+								visitExpression( rs.expression() ) ) :
+						isPresent( rs.expression() ) ? visitExpression( rs.expression() ) : null,
 				null,
 				getPosition( rs ) );
 	}
@@ -1566,9 +1569,11 @@ public class AstOptimizer implements ChoralVisitor {
 		return isPresent( scc.switchArgs() ) ?
 				visitSwitchArgs( scc.switchArgs() ).stream()
 						.map( a -> new AbstractMap.SimpleEntry<>( a, s ) )
-						.collect( Streams.toLinkedHashMap( Map.Entry::getKey, Map.Entry::getValue ) )
-				: Collections.singletonMap(
-				new SwitchArgument.SwitchArgumentDefault( getPosition( scc.getStop() ) ), s );
+						.collect( Streams.toLinkedHashMap(
+								Map.Entry::getKey, Map.Entry::getValue ) ) :
+				Collections.singletonMap(
+						new SwitchArgument.SwitchArgumentDefault( getPosition( scc.getStop() ) ),
+						s );
 	}
 
 	@Override
@@ -1587,7 +1592,6 @@ public class AstOptimizer implements ChoralVisitor {
 		ifPresent( sac.switchArgs() ).apply( s -> l.addAll( visitSwitchArgs( s ) ) );
 		return l;
 	}
-
 
 
 	/* * * * * * * * * * * * GENERIC VISITS * * * * * * * */

--- a/choral/src/main/java/choral/compiler/Typer.java
+++ b/choral/src/main/java/choral/compiler/Typer.java
@@ -129,7 +129,7 @@ public class Typer {
 			visitImportDeclarations( scope, n.imports() );
 		}
 
-		protected void visitImportDeclarations(Scope scope, List< ImportDeclaration > ns ) {
+		protected void visitImportDeclarations( Scope scope, List< ImportDeclaration > ns ) {
 		}
 
 		protected abstract void checkPrimaryTemplate(
@@ -146,7 +146,8 @@ public class Typer {
 				hs.run();     // no-op unless ready
 				if( hs.status() != TaskQueue.Task.Status.FINISHED ) {
 					throw new StaticVerificationException(
-							"Cyclic inheritance: '" + type + "' cannot extend '" + supertype + "'" );
+							"Cyclic inheritance: '" + type + "' cannot extend '" + supertype
+									+ "'" );
 				}
 			}
 		}
@@ -167,7 +168,8 @@ public class Typer {
 					n
 			);
 			n.setTypeAnnotation( t ); // annotate AST
-			ClassOrInterfaceStaticScope classOrInterfaceStaticScope = declarationScope.getScope( t );
+			ClassOrInterfaceStaticScope classOrInterfaceStaticScope =
+					declarationScope.getScope( t );
 			TaskQueue.Task ht = new TaskQueue.Task( Phase.HIERARCHY, () -> {
 				if( n.superClass().isEmpty() ) {
 					t.innerType().setExtendedClass(); // default
@@ -215,9 +217,9 @@ public class Typer {
 							nm.name().identifier(),
 							ms,
 							visitGroundDataTypeExpression(
-									( ms.contains( Modifier.STATIC ) )
-											? classOrInterfaceStaticScope
-											: classOrInterfaceStaticScope.getInstanceScope(),
+									( ms.contains( Modifier.STATIC ) ) ?
+											classOrInterfaceStaticScope :
+											classOrInterfaceStaticScope.getInstanceScope(),
 									nm.typeExpression(), false ) );
 					nm.setTypeAnnotation( tm );
 					tm.setSourceCode( nm );
@@ -242,18 +244,20 @@ public class Typer {
 							typeParams );
 					nm.setTypeAnnotation( tm );
 					tm.setSourceCode( nm );
-					CallableScope callableScope = ( ms.contains( Modifier.STATIC ) )
-							? classOrInterfaceStaticScope.getScope( tm )
-							: classOrInterfaceStaticScope.getInstanceScope().getScope( tm );
+					CallableScope callableScope = ( ms.contains( Modifier.STATIC ) ) ?
+							classOrInterfaceStaticScope.getScope( tm ) :
+							classOrInterfaceStaticScope.getInstanceScope().getScope( tm );
 					visitTypeParametersBound( callableScope, nm.signature().typeParameters(),
 							true );
 					for( VariableDeclaration x : nm.signature().parameters() ) {
 						if( x.type().isEmpty() ) {
 							throw new AstPositionedException( x.position(),
-									new StaticVerificationException( "parameters cannot use the var keyword" ) );
+									new StaticVerificationException(
+											"parameters cannot use the var keyword" ) );
 						}
 						GroundDataType parameterType =
-								visitGroundDataTypeExpression( callableScope, x.type().get(), true );
+								visitGroundDataTypeExpression(
+										callableScope, x.type().get(), true );
 						x.setTypeAnnotation( parameterType );
 						tm.innerCallable().signature().addParameter( x.name().identifier(),
 								parameterType );
@@ -307,17 +311,18 @@ public class Typer {
 							typeParams );
 					nm.setTypeAnnotation( tm );
 					tm.setSourceCode( nm );
-					CallableScope callableScope = classOrInterfaceStaticScope.getInstanceScope().getScope(
-							tm );
-					visitTypeParametersBound( callableScope, nm.signature().typeParameters(),
-							false );
+					CallableScope callableScope = classOrInterfaceStaticScope
+							.getInstanceScope().getScope( tm );
+					visitTypeParametersBound(
+							callableScope, nm.signature().typeParameters(), false );
 					for( VariableDeclaration x : nm.signature().parameters() ) {
 						if( x.type().isEmpty() ) {
 							throw new AstPositionedException( x.position(),
-									new StaticVerificationException( "parameters cannot use the var keyword" ) );
+									new StaticVerificationException(
+											"parameters cannot use the var keyword" ) );
 						}
-						GroundDataType parameterType =
-								visitGroundDataTypeExpression( callableScope, x.type().get(), false );
+						GroundDataType parameterType = visitGroundDataTypeExpression(
+								callableScope, x.type().get(), false );
 						x.setTypeAnnotation( parameterType );
 						tm.innerCallable().signature().addParameter( x.name().identifier(),
 								parameterType );
@@ -356,9 +361,8 @@ public class Typer {
 			String name = n.name().identifier();
 			if( n.worldParameters().size() != 1 ) {
 				throw new AstPositionedException(
-						( n.worldParameters().isEmpty() )
-								? n.position()
-								: n.worldParameters().get( 1 ).position(),
+						( n.worldParameters().isEmpty() ) ? n.position() :
+								n.worldParameters().get( 1 ).position(),
 						new StaticVerificationException( "enums must have exactly one role" ) );
 			}
 			HigherEnum t = new HigherEnum(
@@ -399,8 +403,7 @@ public class Typer {
 		}
 
 		private void visitInterface(
-				CompilationUnitScope declarationScope, Package
-				pkg, choral.ast.body.Interface n
+				CompilationUnitScope declarationScope, Package pkg, choral.ast.body.Interface n
 		) {
 			EnumSet< Modifier > modifiers = EnumSet.noneOf( Modifier.class );
 			for( InterfaceModifier m : n.modifiers() ) {
@@ -453,15 +456,16 @@ public class Typer {
 							typeParams );
 					nm.setTypeAnnotation( tm );
 					tm.setSourceCode( nm );
-					CallableScope methodScope = ( ms.contains( Modifier.STATIC ) )
-							? classOrInterfaceStaticScope.getScope( tm )
-							: classOrInterfaceStaticScope.getInstanceScope().getScope( tm );
+					CallableScope methodScope = ( ms.contains( Modifier.STATIC ) ) ?
+							classOrInterfaceStaticScope.getScope( tm ) :
+							classOrInterfaceStaticScope.getInstanceScope().getScope( tm );
 					visitTypeParametersBound( methodScope, nm.signature().typeParameters(),
 							true );
 					for( VariableDeclaration x : nm.signature().parameters() ) {
 						if( x.type().isEmpty() ) {
 							throw new AstPositionedException( x.position(),
-									new StaticVerificationException( "parameters cannot use the var keyword" ) );
+									new StaticVerificationException(
+											"parameters cannot use the var keyword" ) );
 						}
 						GroundDataType parameterType =
 								visitGroundDataTypeExpression( methodScope, x.type().get(), false );
@@ -585,8 +589,10 @@ public class Typer {
 			}
 		}
 
-		private void checkIfTypeSelectionMethod( Member.HigherMethod tm,
-				List< Annotation > annotations ) {
+		private void checkIfTypeSelectionMethod(
+				Member.HigherMethod tm,
+				List< Annotation > annotations
+		) {
 			for( Annotation x : annotations ) {
 				if( x.getName().identifier().equals( SUPER_SELECTION_METHOD_ANNOTATION ) ) {
 					// TODO: Proper typechecks.
@@ -609,8 +615,7 @@ public class Typer {
 				Map< Member.HigherConstructor, Position > positions
 		);
 
-		private List< World > visitWorldParameters
-				( List< FormalWorldParameter > worldParameters ) {
+		private List< World > visitWorldParameters( List< FormalWorldParameter > worldParameters ) {
 			List< World > result = new ArrayList<>( worldParameters.size() );
 			for( FormalWorldParameter m : worldParameters ) {
 				result.add( visitWorldParameter( m ) );
@@ -697,7 +702,7 @@ public class Typer {
 					return annotate( n, g );
 				}
 			} catch( StaticVerificationException e ) {
-				System.err.println(n.name());
+				System.err.println( n.name() );
 				throw new AstPositionedException( n.position(), e );
 			}
 		}
@@ -910,7 +915,7 @@ public class Typer {
 				TemplateDeclaration n, CompilationUnit cu, String family
 		) {
 			String sourceFile = cu.position().sourceFile();
-			if (sourceFile == null) return;
+			if( sourceFile == null ) return;
 
 			int k = Math.max( 0, sourceFile.lastIndexOf( '.' ) );
 			int j = Math.min( k, sourceFile.lastIndexOf( File.separatorChar ) + 1 );
@@ -966,7 +971,7 @@ public class Typer {
 					throw new StaticVerificationException(
 							"non-abstract methods must have bodies" );
 				} else {
-					callable.addChannel(bodyScope.getChannels());
+					callable.addChannel( bodyScope.getChannels() );
 					boolean returnChecked = check(
 							body, callable.innerCallable().returnType(), bodyScope, callable
 					);
@@ -998,9 +1003,8 @@ public class Typer {
 				}
 			} else {
 				MethodCallExpression n = d.explicitConstructorInvocation().get();
-				GroundClass t = ( "this".equals( n.name().identifier() ) )
-						? (GroundClass) scope.lookupThis()
-						: scope.lookupSuper();
+				GroundClass t = ( "this".equals( n.name().identifier() ) ) ?
+						(GroundClass) scope.lookupThis() : scope.lookupSuper();
 				if( t == null ) {
 					throw new AstPositionedException( n.position(),
 							new StaticVerificationException(
@@ -1012,7 +1016,8 @@ public class Typer {
 						.map( x -> visitHigherReferenceTypeExpression( scope, x, false ) )
 						.collect( Collectors.toList() );
 				List< ? extends GroundDataType > args = n.arguments().stream()
-						.map( x -> assertNotVoid( synth( scope, x, true, callable ), x.position() ) )
+						.map( x -> assertNotVoid( synth( scope, x, true, callable ),
+								x.position() ) )
 						.collect( Collectors.toList() );
 				List< ? extends Member.GroundCallable > ms = findMostSpecificCallable(
 						typeArgs,
@@ -1029,10 +1034,11 @@ public class Typer {
 					throw new AstPositionedException( n.position(),
 							new StaticVerificationException( "ambiguous constructor invocation, " +
 									ms.stream().map( x -> "'" + t +
-													x.signature().parameters().stream()
-															.map( y -> y.type().toString() )
-															.collect( Formatting.joining( ",", "(", ")",
-																	"" ) ) + "'" )
+											x.signature().parameters().stream()
+													.map( y -> y.type().toString() )
+													.collect( Formatting.joining( ",", "(", ")",
+															"" ) )
+											+ "'" )
 											.collect( Collectors.collectingAndThen(
 													Collectors.toList(),
 													Formatting.joiningOxfordComma() ) ) ) );
@@ -1042,7 +1048,7 @@ public class Typer {
 				dependencies.put( callable, selected.higherCallable() );
 				positions.put( callable, n.position() );
 			}
-			callable.addChannel(scope.getChannels()); // find all available channels
+			callable.addChannel( scope.getChannels() ); // find all available channels
 			check( d.blockStatements(), universe().voidType(), scope, callable );
 		}
 
@@ -1051,8 +1057,8 @@ public class Typer {
 				List< ? extends GroundDataType > args,
 				Stream< ? extends Member.HigherCallable > callables
 		) {
-			List< ? extends Member.HigherCallable > cs = callables.filter( x ->
-					x.typeParameters().size() == typeArgs.size() && x.arity() == args.size()
+			List< ? extends Member.HigherCallable > cs = callables.filter(
+					x -> x.typeParameters().size() == typeArgs.size() && x.arity() == args.size()
 			).collect( Collectors.toList() );
 			// find most specific w/o unboxing
 //	/*DEBUG*/
@@ -1089,7 +1095,8 @@ public class Typer {
 									!a.isSubtypeOf( p );
 						} else {
 							if( p.isPrimitive() ) {
-								if( a instanceof GroundClass && ( (GroundClass) a ).isBoxedType() ) {
+								if( a instanceof GroundClass
+										&& ( (GroundClass) a ).isBoxedType() ) {
 									a = ( (GroundClass) a ).unboxedType();
 								}
 							} else {
@@ -1144,10 +1151,9 @@ public class Typer {
 			} while( ms.isEmpty() && phase < 3 );
 //			System.out.println( "=================================================" );
 
-			if ( opts.relaxed() ) {
+			if( opts.relaxed() ) {
 				return filterMethodsUsingWorlds( ms, args );
-			}
-			else {
+			} else {
 				return ms;
 			}
 		}
@@ -1173,28 +1179,28 @@ public class Typer {
 		 * {@code myMethod(1@A, chAB.com(true@A))}---even though they could conceivably
 		 * have wanted us to infer {@code myMethod(chAB.com(1@A), chAB.com(true@A))}.
 		 */
-		private static List<Member.GroundCallable> filterMethodsUsingWorlds(
+		private static List< Member.GroundCallable > filterMethodsUsingWorlds(
 				List< Member.GroundCallable > methods,
 				List< ? extends GroundDataType > args
-		){
-			if (methods.size() <= 1)
+		) {
+			if( methods.size() <= 1 )
 				return methods;
-			for( int i = 0; i < args.size(); i++ ){
+			for( int i = 0; i < args.size(); i++ ) {
 				final int index = i;
-				var argWorlds = args.get(index).worldArguments();
+				var argWorlds = args.get( index ).worldArguments();
 
 				// Find the methods whose i-th parameter world matches our i-th argument world.
 				// If there are no such methods, check if they all have their i-th parameter
 				// at the same world---if so, we can proceed because any of them would require
 				// the same communications.
 				var eligibleMethods = methods.stream()
-						.filter( method -> getParamWorlds(method, index).equals(argWorlds) )
+						.filter( method -> getParamWorlds( method, index ).equals( argWorlds ) )
 						.toList();
-				if( eligibleMethods.isEmpty() ){
-					var firstWorlds = getParamWorlds(methods.get(0), index);
-					boolean allAtSameWorld = methods.stream().allMatch( method ->
-							getParamWorlds(method, index).equals(firstWorlds) );
-					if( !allAtSameWorld ){
+				if( eligibleMethods.isEmpty() ) {
+					var firstWorlds = getParamWorlds( methods.get( 0 ), index );
+					boolean allAtSameWorld = methods.stream().allMatch(
+							method -> getParamWorlds( method, index ).equals( firstWorlds ) );
+					if( !allAtSameWorld ) {
 						return Collections.emptyList();
 					}
 				} else {
@@ -1209,8 +1215,10 @@ public class Typer {
 		 * Returns the list of worlds associated with the i-th parameter of the given method.
 		 * For example, the 1-th world of {@code myMethod(int@A, bool@B)} is B.
 		 */
-		private static List< ? extends World > getParamWorlds( Member.GroundCallable method, int i ){
-			return method.signature().parameters().get(i).type().worldArguments();
+		private static List< ? extends World > getParamWorlds(
+				Member.GroundCallable method, int i
+		) {
+			return method.signature().parameters().get( i ).type().worldArguments();
 		}
 
 		boolean check(
@@ -1229,7 +1237,8 @@ public class Typer {
 				Member.HigherCallable enclosingMethod
 		) {
 			return new Synth(
-					scope, explicitConstructorArg, Collections.emptyList(), enclosingMethod, null, opts
+					scope, explicitConstructorArg, Collections.emptyList(), enclosingMethod, null,
+					opts
 			).visit( n );
 		}
 
@@ -1311,13 +1320,15 @@ public class Typer {
 				return assertReachableContinuation( n, returnChecked );
 			}
 
-			private /* static */ final EnumSet< PrimitiveTypeTag > legalSwitchPrimitiveTypes = EnumSet.of(
-					PrimitiveTypeTag.CHAR, PrimitiveTypeTag.BYTE, PrimitiveTypeTag.SHORT,
-					PrimitiveTypeTag.INT );
+			private /* static */ final EnumSet< PrimitiveTypeTag > legalSwitchPrimitiveTypes =
+					EnumSet.of(
+							PrimitiveTypeTag.CHAR, PrimitiveTypeTag.BYTE, PrimitiveTypeTag.SHORT,
+							PrimitiveTypeTag.INT );
 
-			private /* static */ final EnumSet< SpecialTypeTag > legalSwitchSpecialTypes = EnumSet.of(
-					SpecialTypeTag.BYTE, SpecialTypeTag.SHORT, SpecialTypeTag.INTEGER,
-					SpecialTypeTag.STRING );
+			private /* static */ final EnumSet< SpecialTypeTag > legalSwitchSpecialTypes =
+					EnumSet.of(
+							SpecialTypeTag.BYTE, SpecialTypeTag.SHORT, SpecialTypeTag.INTEGER,
+							SpecialTypeTag.STRING );
 
 			@Override
 			public Boolean visit( SwitchStatement n ) {
@@ -1340,9 +1351,9 @@ public class Typer {
 				boolean returnChecked = true;
 				// determines whether a case falls into the default case or not.
 				boolean hasDefault = false;
-				Set<String> casesFound = new HashSet<>(n.cases().size());
+				Set< String > casesFound = new HashSet<>( n.cases().size() );
 				for( Map.Entry< SwitchArgument< ? >, Statement > entry : n.cases().entrySet() ) {
-					if( entry.getKey() instanceof SwitchArgument.SwitchArgumentLabel label) {
+					if( entry.getKey() instanceof SwitchArgument.SwitchArgumentLabel label ) {
 						if( guard.isEnum() ) {
 							GroundEnum ge = (GroundEnum) guard;
 							String id = label.argument().identifier();
@@ -1350,18 +1361,19 @@ public class Typer {
 								throw new AstPositionedException( label.argument().position(),
 										new UnresolvedSymbolException( id ) );
 							} else {
-								if(!casesFound.add(id)){
+								if( !casesFound.add( id ) ) {
 									throw new AstPositionedException( label.argument().position(),
-										new StaticVerificationException(
-												"duplicate case '" + id + "'" ) );
+											new StaticVerificationException(
+													"duplicate case '" + id + "'" ) );
 								}
 							}
 						} else {
 							throw new AstPositionedException( label.argument().position(),
 									new StaticVerificationException(
-											"required a literal of type '" + guard + "', found a label" ) );
+											"required a literal of type '" + guard
+													+ "', found a label" ) );
 						}
-					} else if( entry.getKey() instanceof SwitchArgument.SwitchArgumentLiteral l) {
+					} else if( entry.getKey() instanceof SwitchArgument.SwitchArgumentLiteral l ) {
 						GroundDataTypeOrVoid argument = synth( l.argument(), n );
 						String s = l.argument().content().toString();
 						if( !argument.isAssignableTo( guard ) ) {
@@ -1369,9 +1381,10 @@ public class Typer {
 									new StaticVerificationException( "required type '" + guard
 											+ "', found '" + guard + "'" ) );
 						}
-						if(!casesFound.add(s)){
+						if( !casesFound.add( s ) ) {
 							throw new AstPositionedException( l.argument().position(),
-									new StaticVerificationException( "duplicate case '" + s + "'" ) );
+									new StaticVerificationException(
+											"duplicate case '" + s + "'" ) );
 						}
 					} else {
 						hasDefault = true;
@@ -1389,7 +1402,8 @@ public class Typer {
 				for( Pair< VariableDeclaration, Statement > c : n.catches() ) {
 					if( c.left().type().isEmpty() ) {
 						throw new AstPositionedException( c.left().position(),
-								new StaticVerificationException( "catch bindings cannot use the var keyword" ) );
+								new StaticVerificationException(
+										"catch bindings cannot use the var keyword" ) );
 					}
 					// get the type of the exception
 					GroundDataType te = visitGroundDataTypeExpression(
@@ -1439,14 +1453,16 @@ public class Typer {
 				} else {
 					if( expected instanceof GroundDataType expected ) {
 						List< ? extends World > expectedLocation = expected.worldArguments();
-						GroundDataTypeOrVoid found = synth( n.returnExpression(), n, expectedLocation );
+						GroundDataTypeOrVoid found =
+								synth( n.returnExpression(), n, expectedLocation );
 						boolean isAssignable = opts.relaxed() ?
 								found.isAssignableTo_relaxed( expected ) :
 								found.isAssignableTo( expected );
 						if( !isAssignable ) {
 							throw new AstPositionedException( n.position(),
 									new StaticVerificationException(
-											"required type '" + expected + "', found '" + found + "'" ) );
+											"required type '" + expected + "', found '" + found
+													+ "'" ) );
 						}
 						return assertReachableContinuation( n, true );
 					} else {
@@ -1465,8 +1481,8 @@ public class Typer {
 						type = visitGroundDataTypeExpression( scope, x.type().get(), false );
 						x.initializer().ifPresent( e -> checkInitializer( e, n, type ) );
 					} else {
-						AssignExpression initializer = x.initializer().orElseThrow( () ->
-								new AstPositionedException( x.position(),
+						AssignExpression initializer = x.initializer()
+								.orElseThrow( () -> new AstPositionedException( x.position(),
 										new StaticVerificationException(
 												"var declarations require an initializer" ) ) );
 						type = assertNotVoid(
@@ -1507,7 +1523,8 @@ public class Typer {
 			}
 
 			private void checkInitializer(
-					AssignExpression initializer, Statement statement, GroundDataType declaredType ) {
+					AssignExpression initializer, Statement statement, GroundDataType declaredType
+			) {
 				initializer.target().setTypeAnnotation( declaredType );
 				initializer.setTypeAnnotation( declaredType );
 				GroundDataTypeOrVoid found =
@@ -1518,7 +1535,8 @@ public class Typer {
 				if( !assignable ) {
 					throw new AstPositionedException( initializer.position(),
 							new StaticVerificationException(
-									"required type '" + declaredType + "', found '" + found + "'" ) );
+									"required type '" + declaredType + "', found '" + found
+											+ "'" ) );
 				}
 			}
 
@@ -1535,12 +1553,12 @@ public class Typer {
 		private final class Synth extends AbstractChoralVisitor< GroundDataTypeOrVoid > {
 
 			public Synth(
-				VariableDeclarationScope scope,
-				boolean explicitConstructorArg,
-				List< ? extends World > homeWorlds,
-				HigherCallable method,
-				Statement statement,
-				TyperOptions opts
+					VariableDeclarationScope scope,
+					boolean explicitConstructorArg,
+					List< ? extends World > homeWorlds,
+					HigherCallable method,
+					Statement statement,
+					TyperOptions opts
 			) {
 				this.scope = scope;
 				this.explicitConstructorArg = explicitConstructorArg;
@@ -1578,13 +1596,15 @@ public class Typer {
 
 			GroundDataTypeOrVoid synth( Expression n ) {
 				return new Synth(
-						scope, explicitConstructorArg, homeWorlds, enclosingMethod, enclosingStatement, opts
+						scope, explicitConstructorArg, homeWorlds, enclosingMethod,
+						enclosingStatement, opts
 				).visit( n );
 			}
 
 			GroundDataTypeOrVoid synth( Expression n, List< ? extends World > homeWorlds ) {
 				return new Synth(
-					scope, explicitConstructorArg, homeWorlds, enclosingMethod, enclosingStatement, opts
+						scope, explicitConstructorArg, homeWorlds, enclosingMethod,
+						enclosingStatement, opts
 				).visit( n );
 			}
 
@@ -1620,8 +1640,8 @@ public class Typer {
 				// ...turn bookkeeping back on for the relaxed typer and record any dependencies
 				// if `n` is the innermost part of the scoped expression.
 				homeWorlds = savedHomeWorlds;
-				if( !(n.scopedExpression() instanceof ScopedExpression) ){
-					recordDependencies(n, right, homeWorlds);
+				if( !( n.scopedExpression() instanceof ScopedExpression ) ) {
+					recordDependencies( n, right, homeWorlds );
 				}
 
 				left = null;
@@ -1635,20 +1655,22 @@ public class Typer {
 				if( result == null ) {
 					throw new AstPositionedException( position,
 							new StaticVerificationException(
-									"primitive type expected, '" + type + "' cannot be converted" ) );
+									"primitive type expected, '" + type
+											+ "' cannot be converted" ) );
 				} else {
 					return result;
 				}
 			}
 
 			private GroundPrimitiveDataType unbox( GroundDataTypeOrVoid type ) {
-				if( type instanceof GroundPrimitiveDataType groundType) {
+				if( type instanceof GroundPrimitiveDataType groundType ) {
 					return groundType;
 				}
-				if( type instanceof GroundClass groundClass) {
+				if( type instanceof GroundClass groundClass ) {
 					for( PrimitiveTypeTag p : PrimitiveTypeTag.values() ) {
 						if( p.boxedType() == groundClass.specialTypeTag() ) {
-							return universe().primitiveDataType( p ).applyTo( groundClass.worldArguments() );
+							return universe().primitiveDataType( p )
+									.applyTo( groundClass.worldArguments() );
 						}
 					}
 				}
@@ -1672,16 +1694,14 @@ public class Typer {
 				GroundDataType rightType = (GroundDataType) tvr;
 
 				List< ? extends World > worlds;
-				if ( opts.relaxed() ) {
+				if( opts.relaxed() ) {
 					worlds = homeWorlds.isEmpty() ? leftType.worldArguments() : homeWorlds;
-				}
-				else {
+				} else {
 					worlds = leftType.worldArguments();
 
 					if( !( leftType.worldArguments().size() == 1 &&
 							rightType.worldArguments().size() == 1 &&
-							leftType.worldArguments().equals( rightType.worldArguments() )
-							)
+							leftType.worldArguments().equals( rightType.worldArguments() ) )
 					) {
 						throw new AstPositionedException( position,
 								new StaticVerificationException( "cannot apply '"
@@ -1697,9 +1717,10 @@ public class Typer {
 						if( leftType.specialTypeTag() == SpecialTypeTag.STRING
 								|| rightType.specialTypeTag() == SpecialTypeTag.STRING
 								|| ( ( leftType.specialTypeTag() == SpecialTypeTag.CHARACTER ||
-								leftType.primitiveTypeTag() == PrimitiveTypeTag.CHAR ) &&
-								( rightType.specialTypeTag() == SpecialTypeTag.CHARACTER ||
-										rightType.primitiveTypeTag() == PrimitiveTypeTag.CHAR ) )
+										leftType.primitiveTypeTag() == PrimitiveTypeTag.CHAR ) &&
+										( rightType.specialTypeTag() == SpecialTypeTag.CHARACTER ||
+												rightType
+														.primitiveTypeTag() == PrimitiveTypeTag.CHAR ) )
 						) {
 							return universe().specialType( SpecialTypeTag.STRING )
 									.applyTo( worlds );
@@ -1711,11 +1732,11 @@ public class Typer {
 					case REMAINDER:
 						pl = assertUnbox( leftType, position );
 						pr = assertUnbox( rightType, position );
-						if( pl.primitiveTypeTag().isNumeric() && pr.primitiveTypeTag().isNumeric() ) {
+						if( pl.primitiveTypeTag().isNumeric()
+								&& pr.primitiveTypeTag().isNumeric() ) {
 							GroundPrimitiveDataType p =
-									( pl.primitiveTypeTag().compareTo( pr.primitiveTypeTag() ) > 0 )
-									? pl
-									: pr;
+									( pl.primitiveTypeTag()
+											.compareTo( pr.primitiveTypeTag() ) > 0 ) ? pl : pr;
 							if( p.primitiveTypeTag().compareTo( PrimitiveTypeTag.INT ) < 0 ) {
 								p = universe().primitiveDataType( PrimitiveTypeTag.INT )
 										.applyTo( worlds );
@@ -1730,7 +1751,8 @@ public class Typer {
 					case GREATER_EQUALS:
 						pl = assertUnbox( leftType, position );
 						pr = assertUnbox( rightType, position );
-						if( pl.primitiveTypeTag().isNumeric() && pr.primitiveTypeTag().isNumeric() ) {
+						if( pl.primitiveTypeTag().isNumeric()
+								&& pr.primitiveTypeTag().isNumeric() ) {
 							return universe().primitiveDataType( PrimitiveTypeTag.BOOLEAN )
 									.applyTo( worlds );
 						}
@@ -1739,7 +1761,8 @@ public class Typer {
 					case AND:
 						pl = assertUnbox( leftType, position );
 						pr = assertUnbox( rightType, position );
-						if( pl.primitiveTypeTag().isIntegral() && pr.primitiveTypeTag().isIntegral() ) {
+						if( pl.primitiveTypeTag().isIntegral()
+								&& pr.primitiveTypeTag().isIntegral() ) {
 							if( pl.primitiveTypeTag().compareTo( pr.primitiveTypeTag() ) > 0 ) {
 								return universe().primitiveDataType( pl.primitiveTypeTag() )
 										.applyTo( worlds );
@@ -1759,17 +1782,22 @@ public class Typer {
 						break;
 					case EQUALS:
 					case NOT_EQUALS:
-						boolean trSubtype = opts.relaxed() ? rightType.isSubtypeOf_relaxed( leftType ) : rightType.isSubtypeOf( leftType );
-						boolean tlSubtype = opts.relaxed() ? leftType.isSubtypeOf_relaxed( rightType ) : leftType.isSubtypeOf( rightType );
+						boolean trSubtype =
+								opts.relaxed() ? rightType.isSubtypeOf_relaxed( leftType ) :
+										rightType.isSubtypeOf( leftType );
+						boolean tlSubtype =
+								opts.relaxed() ? leftType.isSubtypeOf_relaxed( rightType ) :
+										leftType.isSubtypeOf( rightType );
 						if( ( leftType instanceof GroundReferenceType && trSubtype ) ||
-							( rightType instanceof GroundReferenceType && tlSubtype ) ) {
+								( rightType instanceof GroundReferenceType && tlSubtype ) ) {
 							return universe().primitiveDataType( PrimitiveTypeTag.BOOLEAN )
 									.applyTo( worlds );
 						} else {
 							pl = assertUnbox( leftType, position );
 							pr = assertUnbox( rightType, position );
 							if( pl.primitiveTypeTag() == pr.primitiveTypeTag() ||
-									( pl.primitiveTypeTag().isNumeric() && pr.primitiveTypeTag().isNumeric() )
+									( pl.primitiveTypeTag().isNumeric()
+											&& pr.primitiveTypeTag().isNumeric() )
 							) {
 								return universe().primitiveDataType( PrimitiveTypeTag.BOOLEAN )
 										.applyTo( worlds );
@@ -1836,7 +1864,7 @@ public class Typer {
 				// In "relaxed" typing mode, we let the left arguments determine where the
 				// expression should be evaluated.
 				if( homeWorlds.isEmpty() && !tl.isVoid() )
-					homeWorlds = ((GroundDataType)tl).worldArguments();
+					homeWorlds = ( (GroundDataType) tl ).worldArguments();
 				GroundDataTypeOrVoid tr = synth( n.right() );
 				// the expression n, is annotated with a primitive type with world(s)
 				// the type being the type of the entire binary expression
@@ -1875,7 +1903,7 @@ public class Typer {
 					throw new AstPositionedException( n.position(),
 							new UnresolvedSymbolException( identifier ) );
 				} else {
-					recordDependencies(n, result.get(), homeWorlds);
+					recordDependencies( n, result.get(), homeWorlds );
 					return annotate( n, result.get() );
 				}
 			}
@@ -1910,7 +1938,8 @@ public class Typer {
 							new StaticVerificationException(
 									"'" + t + "' is abstract, cannot be instantiated" ) );
 				}
-				Pair<List< ? extends HigherReferenceType >, List< ? extends GroundDataType >> typeargsArgs = getArgsTypeargs(scope, n);
+				Pair< List< ? extends HigherReferenceType >, List< ? extends GroundDataType > > typeargsArgs =
+						getArgsTypeargs( scope, n );
 
 				List< ? extends Member.GroundCallable > ms = findMostSpecificCallable(
 						typeargsArgs.left(),
@@ -1920,17 +1949,19 @@ public class Typer {
 				if( ms.isEmpty() ) {
 					throw new AstPositionedException( n.position(),
 							new StaticVerificationException( "cannot resolve constructor '" + t +
-									typeargsArgs.right().stream().map( Object::toString ).collect( Formatting
-											.joining( ",", "(", ")", "" ) )
+									typeargsArgs.right().stream().map( Object::toString )
+											.collect( Formatting
+													.joining( ",", "(", ")", "" ) )
 									+ "'" ) );
 				} else if( ms.size() > 1 ) {
 					throw new AstPositionedException( n.position(),
 							new StaticVerificationException( "ambiguous constructor invocation, " +
 									ms.stream().map( x -> "'" + t +
-													x.signature().parameters().stream()
-															.map( y -> y.type().toString() )
-															.collect( Formatting.joining( ",", "(", ")",
-																	"" ) ) + "'" )
+											x.signature().parameters().stream()
+													.map( y -> y.type().toString() )
+													.collect( Formatting.joining( ",", "(", ")",
+															"" ) )
+											+ "'" )
 											.collect( Collectors.collectingAndThen(
 													Collectors.toList(),
 													Formatting.joiningOxfordComma() ) ) ) );
@@ -1938,7 +1969,7 @@ public class Typer {
 				Member.GroundConstructor selected = (Member.GroundConstructor) ms.get( 0 );
 				n.setConstructorAnnotation( selected );
 
-				recordDependencies(selected, n.arguments());
+				recordDependencies( selected, n.arguments() );
 
 				leftStatic = false;
 				return t;
@@ -1950,9 +1981,10 @@ public class Typer {
 					left = scope.lookupThis();
 					leftStatic = isInStaticContext();
 				}
-				Pair<List< ? extends HigherReferenceType >, List< ? extends GroundDataType >> typeargsArgs = getArgsTypeargs(scope, n);
+				Pair< List< ? extends HigherReferenceType >, List< ? extends GroundDataType > > typeargsArgs =
+						getArgsTypeargs( scope, n );
 
-				if( left instanceof GroundReferenceType type) {
+				if( left instanceof GroundReferenceType type ) {
 					List< ? extends Member.GroundCallable > ms = findMostSpecificCallable(
 							typeargsArgs.left(),
 							typeargsArgs.right(),
@@ -1962,33 +1994,35 @@ public class Typer {
 						throw new AstPositionedException( n.position(),
 								new StaticVerificationException( "cannot resolve method '"
 										+ n.name().identifier()
-										+ typeargsArgs.right().stream().map( Object::toString ).collect( Formatting
-										.joining( ",", "(", ")", "" ) )
+										+ typeargsArgs.right().stream().map( Object::toString )
+												.collect( Formatting
+														.joining( ",", "(", ")", "" ) )
 										+ "' in '" + type + "'" ) );
-					}
-					else if( ms.size() > 1 ) {
+					} else if( ms.size() > 1 ) {
 						throw new AstPositionedException( n.position(),
 								new StaticVerificationException(
 										"ambiguous method invocation, " +
 												ms.stream().map( Member.GroundCallable::toString )
 														.collect( Collectors.collectingAndThen(
 																Collectors.toList(),
-																Formatting.joiningOxfordComma() ) ) ) );
+																Formatting
+																		.joiningOxfordComma() ) ) ) );
 					}
 					Member.GroundMethod selected = (Member.GroundMethod) ms.get( 0 );
 					n.setMethodAnnotation( selected );
 					leftStatic = false;
 
-					recordDependencies(selected, n.arguments());
-					recordDependencies(n, selected.returnType(), homeWorlds);
+					recordDependencies( selected, n.arguments() );
+					recordDependencies( n, selected.returnType(), homeWorlds );
 
-					return annotate( n, selected.returnType());
+					return annotate( n, selected.returnType() );
 				} else {
 					throw new AstPositionedException( n.position(),
 							new StaticVerificationException( "cannot resolve method '"
 									+ n.name().identifier()
-									+ typeargsArgs.right().stream().map( Object::toString ).collect( Formatting
-									.joining( ",", "(", ")", "" ) )
+									+ typeargsArgs.right().stream().map( Object::toString )
+											.collect( Formatting
+													.joining( ",", "(", ")", "" ) )
 									+ "' in 'void'" ) );
 				}
 			}
@@ -1998,8 +2032,9 @@ public class Typer {
 			 * ClassInstantiationExpression. Type arguments are stored in the left value, and
 			 * regular arguments in the right value.
 			 */
-			public Pair<List< ? extends HigherReferenceType >, List< ? extends GroundDataType >>
-				getArgsTypeargs(VariableDeclarationScope scope, InvocationExpression expression) {
+			public Pair< List< ? extends HigherReferenceType >, List< ? extends GroundDataType > > getArgsTypeargs(
+					VariableDeclarationScope scope, InvocationExpression expression
+			) {
 
 				List< ? extends HigherReferenceType > typeArgs = expression.typeArguments().stream()
 						.map( x -> visitHigherReferenceTypeExpression( scope, x, false ) )
@@ -2069,7 +2104,7 @@ public class Typer {
 			}
 
 			public GroundDataType visit( LiteralExpression.BooleanLiteralExpression n ) {
-				checkWorlds(n);
+				checkWorlds( n );
 
 				return annotate( n, universe()
 						.primitiveDataType( PrimitiveTypeTag.BOOLEAN )
@@ -2077,7 +2112,7 @@ public class Typer {
 			}
 
 			public GroundDataType visit( LiteralExpression.IntegerLiteralExpression n ) {
-				checkWorlds(n);
+				checkWorlds( n );
 
 				return annotate( n, universe()
 						.primitiveDataType( PrimitiveTypeTag.INT )
@@ -2085,7 +2120,7 @@ public class Typer {
 			}
 
 			public GroundDataType visit( LiteralExpression.DoubleLiteralExpression n ) {
-				checkWorlds(n);
+				checkWorlds( n );
 
 				return annotate( n, universe()
 						.primitiveDataType( PrimitiveTypeTag.DOUBLE )
@@ -2093,7 +2128,7 @@ public class Typer {
 			}
 
 			public GroundDataType visit( LiteralExpression.StringLiteralExpression n ) {
-				checkWorlds(n);
+				checkWorlds( n );
 
 				return annotate( n, universe()
 						.specialType( SpecialTypeTag.STRING )
@@ -2112,14 +2147,14 @@ public class Typer {
 			 * @param toWorlds The place where the expression's result should be located
 			 */
 			private void recordDependencies(
-				Expression expression,
-				GroundDataTypeOrVoid type,
-				List< ? extends World > toWorlds
-			){
-				if (!opts.relaxed() || type.isVoid()) return;
-				var foreignWorlds = ((GroundDataType) type).worldArguments();
-				if( !toWorlds.containsAll( foreignWorlds ) ){
-					enclosingMethod.addDependencies(toWorlds, expression, enclosingStatement);
+					Expression expression,
+					GroundDataTypeOrVoid type,
+					List< ? extends World > toWorlds
+			) {
+				if( !opts.relaxed() || type.isVoid() ) return;
+				var foreignWorlds = ( (GroundDataType) type ).worldArguments();
+				if( !toWorlds.containsAll( foreignWorlds ) ) {
+					enclosingMethod.addDependencies( toWorlds, expression, enclosingStatement );
 				}
 			}
 
@@ -2132,26 +2167,26 @@ public class Typer {
 			 *             have type annotations
 			 */
 			private void recordDependencies(
-				Member.GroundCallable method,
-				List< Expression > args
+					Member.GroundCallable method,
+					List< Expression > args
 			) {
-				if ( !opts.relaxed() ) return;
-				for( int i = 0; i < args.size(); i++ ){
+				if( !opts.relaxed() ) return;
+				for( int i = 0; i < args.size(); i++ ) {
 					var toWorlds = getParamWorlds( method, i );
-					var argument = args.get(i);
+					var argument = args.get( i );
 					var argType = argument.typeAnnotation().get();
-					recordDependencies(argument, argType, toWorlds);
+					recordDependencies( argument, argType, toWorlds );
 				}
 			}
 
 			/** Throws an exception if the literal isn't in the world we expect it to be in. */
-			private <T extends LiteralExpression<?>> void checkWorlds( T n ){
-				if ( !opts.relaxed() ) return;
-				if( !homeWorlds.isEmpty() && !homeWorlds.contains( visitWorld( n.world() ) ) ){
+			private < T extends LiteralExpression< ? > > void checkWorlds( T n ) {
+				if( !opts.relaxed() ) return;
+				if( !homeWorlds.isEmpty() && !homeWorlds.contains( visitWorld( n.world() ) ) ) {
 					throw new AstPositionedException( n.position(),
-							 new StaticVerificationException(
-									 "Literal '" + n + "', can't be used in an expression at role '"
-									 + homeWorlds + "'" ) );
+							new StaticVerificationException(
+									"Literal '" + n + "', can't be used in an expression at role '"
+											+ homeWorlds + "'" ) );
 				}
 			}
 

--- a/choral/src/main/java/choral/compiler/Typer.java
+++ b/choral/src/main/java/choral/compiler/Typer.java
@@ -1460,13 +1460,21 @@ public class Typer {
 			@Override
 			public Boolean visit( VariableDeclarationStatement n ) {
 				for( VariableDeclaration x : n.variables() ) {
-					if( x.type().isEmpty() ) {
-						throw new AstPositionedException( x.position(),
-								new StaticVerificationException( "The var keyword is not yet supported" ) );
+					GroundDataType type;
+					if( x.type().isPresent() ) {
+						type = visitGroundDataTypeExpression( scope, x.type().get(), false );
+						x.initializer().ifPresent( e -> checkInitializer( e, n, type ) );
+					} else {
+						AssignExpression initializer = x.initializer().orElseThrow( () ->
+								new AstPositionedException( x.position(),
+										new StaticVerificationException(
+												"var declarations require an initializer" ) ) );
+						type = assertNotVoid(
+								synth( initializer.value(), n ), initializer.value().position() );
+						initializer.target().setTypeAnnotation( type );
+						initializer.setTypeAnnotation( type );
 					}
-					GroundDataType type = visitGroundDataTypeExpression( scope, x.type().get(), false );
 					x.setTypeAnnotation( type );
-					x.initializer().ifPresent( e -> checkInitializer( e, n, type ) );
 					scope.declareVariable( x );
 				}
 				return assertReachableContinuation( n, false );

--- a/choral/src/main/java/choral/compiler/Typer.java
+++ b/choral/src/main/java/choral/compiler/Typer.java
@@ -248,8 +248,12 @@ public class Typer {
 					visitTypeParametersBound( callableScope, nm.signature().typeParameters(),
 							true );
 					for( VariableDeclaration x : nm.signature().parameters() ) {
+						if( x.type().isEmpty() ) {
+							throw new AstPositionedException( x.position(),
+									new StaticVerificationException( "parameters cannot use the var keyword" ) );
+						}
 						GroundDataType parameterType =
-								visitGroundDataTypeExpression( callableScope, x.type(), true );
+								visitGroundDataTypeExpression( callableScope, x.type().get(), true );
 						x.setTypeAnnotation( parameterType );
 						tm.innerCallable().signature().addParameter( x.name().identifier(),
 								parameterType );
@@ -308,8 +312,12 @@ public class Typer {
 					visitTypeParametersBound( callableScope, nm.signature().typeParameters(),
 							false );
 					for( VariableDeclaration x : nm.signature().parameters() ) {
+						if( x.type().isEmpty() ) {
+							throw new AstPositionedException( x.position(),
+									new StaticVerificationException( "parameters cannot use the var keyword" ) );
+						}
 						GroundDataType parameterType =
-								visitGroundDataTypeExpression( callableScope, x.type(), false );
+								visitGroundDataTypeExpression( callableScope, x.type().get(), false );
 						x.setTypeAnnotation( parameterType );
 						tm.innerCallable().signature().addParameter( x.name().identifier(),
 								parameterType );
@@ -451,8 +459,12 @@ public class Typer {
 					visitTypeParametersBound( methodScope, nm.signature().typeParameters(),
 							true );
 					for( VariableDeclaration x : nm.signature().parameters() ) {
+						if( x.type().isEmpty() ) {
+							throw new AstPositionedException( x.position(),
+									new StaticVerificationException( "parameters cannot use the var keyword" ) );
+						}
 						GroundDataType parameterType =
-								visitGroundDataTypeExpression( methodScope, x.type(), false );
+								visitGroundDataTypeExpression( methodScope, x.type().get(), false );
 						x.setTypeAnnotation( parameterType );
 						tm.innerCallable().signature().addParameter( x.name().identifier(),
 								parameterType );
@@ -1375,9 +1387,13 @@ public class Typer {
 				boolean returnChecked = visitAsInBlock( n.body() );
 				// The "VariableDeclaration" here represents the caught exception
 				for( Pair< VariableDeclaration, Statement > c : n.catches() ) {
+					if( c.left().type().isEmpty() ) {
+						throw new AstPositionedException( c.left().position(),
+								new StaticVerificationException( "catch bindings cannot use the var keyword" ) );
+					}
 					// get the type of the exception
 					GroundDataType te = visitGroundDataTypeExpression(
-							scope, c.left().type(), false );
+							scope, c.left().type().get(), false );
 					GroundClassOrInterface expectedType = universe()
 							.specialType( SpecialTypeTag.EXCEPTION )
 							.applyTo( te.worldArguments() );
@@ -1386,7 +1402,7 @@ public class Typer {
 							te.isSubtypeOf( expectedType );
 					// exceptions only allowed one role
 					if( te.worldArguments().size() > 1 || !isSubtype ) {
-						throw new AstPositionedException( c.left().type().position(),
+						throw new AstPositionedException( c.left().type().get().position(),
 								new StaticVerificationException( "required an instance of type '"
 										+ SpecialTypeTag.EXCEPTION
 										+ "', found '" + te + "'" ) );
@@ -1444,7 +1460,11 @@ public class Typer {
 			@Override
 			public Boolean visit( VariableDeclarationStatement n ) {
 				for( VariableDeclaration x : n.variables() ) {
-					GroundDataType type = visitGroundDataTypeExpression( scope, x.type(), false );
+					if( x.type().isEmpty() ) {
+						throw new AstPositionedException( x.position(),
+								new StaticVerificationException( "The var keyword is not yet supported" ) );
+					}
+					GroundDataType type = visitGroundDataTypeExpression( scope, x.type().get(), false );
 					x.setTypeAnnotation( type );
 					x.initializer().ifPresent( e -> checkInitializer( e, n, type ) );
 					scope.declareVariable( x );

--- a/choral/src/main/java/choral/compiler/courtesyMethodSynthesiser/CourtesyMethodsSynthesiser.java
+++ b/choral/src/main/java/choral/compiler/courtesyMethodSynthesiser/CourtesyMethodsSynthesiser.java
@@ -141,10 +141,12 @@ public class CourtesyMethodsSynthesiser extends AbstractChoralVisitor< Node > {
 					n.modifiers(),
 					n.position()
 			) );
-			MethodCallExpression proxyMethod = new MethodCallExpression( n.signature().name(), parameterBypass, typeParameters );
-			Statement proxyStatement = n.signature().returnType().name().identifier().equals( "void" ) ?
-					new ExpressionStatement( proxyMethod, new NilStatement() )
-					: new ReturnStatement( proxyMethod, new NilStatement() );
+			MethodCallExpression proxyMethod = new MethodCallExpression( n.signature().name(),
+					parameterBypass, typeParameters );
+			Statement proxyStatement =
+					n.signature().returnType().name().identifier().equals( "void" ) ?
+							new ExpressionStatement( proxyMethod, new NilStatement() ) :
+							new ReturnStatement( proxyMethod, new NilStatement() );
 			return new ClassMethodDefinition(
 					visit( n.signature() ),
 					n.body().isPresent() ? proxyStatement : null,
@@ -196,10 +198,12 @@ public class CourtesyMethodsSynthesiser extends AbstractChoralVisitor< Node > {
 					n.modifiers(),
 					n.position()
 			) );
-			MethodCallExpression proxyMethod = new MethodCallExpression( n.signature().name(), parameterBypass, typeParameters );
-			Statement proxyStatement = n.signature().returnType().name().identifier().equals( "void" ) ?
-					new ExpressionStatement( proxyMethod, new NilStatement() )
-					: new ReturnStatement( proxyMethod, new NilStatement() );
+			MethodCallExpression proxyMethod = new MethodCallExpression( n.signature().name(),
+					parameterBypass, typeParameters );
+			Statement proxyStatement =
+					n.signature().returnType().name().identifier().equals( "void" ) ?
+							new ExpressionStatement( proxyMethod, new NilStatement() ) :
+							new ReturnStatement( proxyMethod, new NilStatement() );
 			return new InterfaceMethodDefinition(
 					visit( n.signature() ),
 					n.body().isPresent() ? proxyStatement : null,
@@ -250,10 +254,7 @@ public class CourtesyMethodsSynthesiser extends AbstractChoralVisitor< Node > {
 			);
 			List< Expression > parameterBypass = n.signature().parameters().stream()
 					.filter( p -> !unitParameters.contains( p.name() ) )
-					.map( p -> // unitParameters.contains( p.name() ) ?
-							//UnitRepresentation.UnitFD( new WorldArgument( new Name( "" ) ) )
-							//				:
-							new FieldAccessExpression( p.name() ) )
+					.map( p -> new FieldAccessExpression( p.name() ) )
 					.collect( Collectors.toList() );
 			MethodCallExpression proxyConstructor =
 					new MethodCallExpression( new Name( "this" ),

--- a/choral/src/main/java/choral/compiler/courtesyMethodSynthesiser/CourtesyMethodsSynthesiser.java
+++ b/choral/src/main/java/choral/compiler/courtesyMethodSynthesiser/CourtesyMethodsSynthesiser.java
@@ -91,14 +91,14 @@ public class CourtesyMethodsSynthesiser extends AbstractChoralVisitor< Node > {
 
 	private Set< Name > _visit( MethodSignature n ) {
 		return n.parameters().stream()
-				.filter( p -> p.type().name().equals( UnitRepresentation.UNIT ) )
+				.filter( p -> p.type().get().name().equals( UnitRepresentation.UNIT ) )
 				.map( VariableDeclaration::name )
 				.collect( Collectors.toSet() );
 	}
 
 	private Set< Name > _visit( ConstructorSignature n ) {
 		return n.parameters().stream()
-				.filter( p -> p.type().name().equals( UnitRepresentation.UNIT ) )
+				.filter( p -> p.type().get().name().equals( UnitRepresentation.UNIT ) )
 				.map( VariableDeclaration::name )
 				.collect( Collectors.toSet() );
 	}

--- a/choral/src/main/java/choral/compiler/merge/StatementsMerger.java
+++ b/choral/src/main/java/choral/compiler/merge/StatementsMerger.java
@@ -81,7 +81,8 @@ public class StatementsMerger extends AbstractMerger< Statement > {
 		MergeException._assert(
 				n1.variables().size() == n2.variables().size(),
 				"Cannot merge variable declaration expressions due to different variable sizes: "
-						+ n1.variables().size() + " and " + n2.variables().size(), n1, n2
+						+ n1.variables().size() + " and " + n2.variables().size(),
+				n1, n2
 		);
 		List< VariableDeclaration > v = new ArrayList<>();
 		for( int i = 0; i < n1.variables().size(); i++ ) {
@@ -104,7 +105,8 @@ public class StatementsMerger extends AbstractMerger< Statement > {
 	}
 
 	private static Pair< Map< SwitchArgument< ? >, Statement >, Optional< Map.Entry< SwitchArgument< ? >, Statement > > > checkSingleDefaultCase(
-			SwitchStatement s ) {
+			SwitchStatement s
+	) {
 		Map< SwitchArgument< ? >, Statement > cases = new LinkedHashMap<>();
 		Optional< Map.Entry< SwitchArgument< ? >, Statement > > def = Optional.empty();
 
@@ -188,7 +190,8 @@ public class StatementsMerger extends AbstractMerger< Statement > {
 	public TryCatchStatement merge( TryCatchStatement n1, TryCatchStatement n2 ) {
 		MergeException._assert( n1.catches().size() == n2.catches().size(),
 				"Cannot merge try-catch statements with different number of catch clauses: "
-						+ n1.catches().size() + " and " + n2.catches().size(), n1, n2
+						+ n1.catches().size() + " and " + n2.catches().size(),
+				n1, n2
 		);
 		List< Pair< VariableDeclaration, Statement > > mergedCatches = new ArrayList<>();
 		for( int i = 0; i < n1.catches().size(); i++ ) {

--- a/choral/src/main/java/choral/compiler/merge/StatementsMerger.java
+++ b/choral/src/main/java/choral/compiler/merge/StatementsMerger.java
@@ -193,8 +193,8 @@ public class StatementsMerger extends AbstractMerger< Statement > {
 		List< Pair< VariableDeclaration, Statement > > mergedCatches = new ArrayList<>();
 		for( int i = 0; i < n1.catches().size(); i++ ) {
 			MergeException._assert(
-					n1.catches().get( i ).left().type().equals(
-							n2.catches().get( i ).left().type() ),
+					n1.catches().get( i ).left().type().get().equals(
+							n2.catches().get( i ).left().type().get() ),
 					"Cannot merge try-catch statements with non-corresponding catch clauses: ", n1,
 					n2
 			);

--- a/choral/src/main/java/choral/compiler/merge/VariableDeclarationMerger.java
+++ b/choral/src/main/java/choral/compiler/merge/VariableDeclarationMerger.java
@@ -42,11 +42,14 @@ class VariableDeclarationMerger extends AbstractMerger< VariableDeclaration > {
 		);
 		MergeException._assert(
 				n1.inferredTypeExpression().equals( n2.inferredTypeExpression() ),
-				errorPrefix + "different types:  " + n1.inferredTypeExpression() + " and " + n2.inferredTypeExpression(), n1, n2
+				errorPrefix + "different types:  " + n1.inferredTypeExpression() + " and "
+						+ n2.inferredTypeExpression(),
+				n1, n2
 		);
 		MergeException._assert(
 				n1.annotations().equals( n2.annotations() ),
-				errorPrefix + "different annotation lists: " + n1.annotations() + " and " + n2.annotations(),
+				errorPrefix + "different annotation lists: " + n1.annotations() + " and "
+						+ n2.annotations(),
 				n1, n2
 		);
 
@@ -54,17 +57,19 @@ class VariableDeclarationMerger extends AbstractMerger< VariableDeclaration > {
 		MergeException._assert(
 				( i1.isPresent() && i2.isPresent() ) || ( i1.isEmpty() && i2.isEmpty() ),
 				errorPrefix + "different initializers: " + i1.orElse( null ) + " and " + i2.orElse(
-						null ), n1, n2
+						null ),
+				n1, n2
 		);
 
 		return new VariableDeclaration(
 				n1.name(),
 				n1.inferredTypeExpression(),
 				n1.annotations(),
-				i1.isPresent() && i2.isPresent()
-						? (AssignExpression) ExpressionsMerger.mergeExpressions( i1.get(),
-						i2.get() )
-						: null,
+				i1.isPresent() && i2.isPresent() ?
+						(AssignExpression) ExpressionsMerger.mergeExpressions(
+								i1.get(), i2.get()
+						) :
+						null,
 				n1.modifiers()
 		);
 	}

--- a/choral/src/main/java/choral/compiler/merge/VariableDeclarationMerger.java
+++ b/choral/src/main/java/choral/compiler/merge/VariableDeclarationMerger.java
@@ -41,8 +41,8 @@ class VariableDeclarationMerger extends AbstractMerger< VariableDeclaration > {
 				errorPrefix + "different variable names: " + n1.name() + " and " + n2.name(), n1, n2
 		);
 		MergeException._assert(
-				n1.type().equals( n2.type() ),
-				errorPrefix + "different types:  " + n1.type() + " and " + n2.type(), n1, n2
+				n1.inferredTypeExpression().equals( n2.inferredTypeExpression() ),
+				errorPrefix + "different types:  " + n1.inferredTypeExpression() + " and " + n2.inferredTypeExpression(), n1, n2
 		);
 		MergeException._assert(
 				n1.annotations().equals( n2.annotations() ),
@@ -59,7 +59,7 @@ class VariableDeclarationMerger extends AbstractMerger< VariableDeclaration > {
 
 		return new VariableDeclaration(
 				n1.name(),
-				n1.type(),
+				n1.inferredTypeExpression(),
 				n1.annotations(),
 				i1.isPresent() && i2.isPresent()
 						? (AssignExpression) ExpressionsMerger.mergeExpressions( i1.get(),

--- a/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/GenerateMiniZincInputs.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/GenerateMiniZincInputs.java
@@ -344,11 +344,11 @@ public class GenerateMiniZincInputs {
 		 */
 		private void visitVariableDeclaration( VariableDeclaration vd, Statement n ){
 			
-			String variable = vd.type().typeAnnotation().get() + " " + vd.name();
+			String variable = vd.typeAnnotation().get() + " " + vd.name();
 			input.in_size ++;
 			
 			input.statements_blocks.add(currentBlock);
-			input.statements_roles.add(new World( new Universe(), vd.type().worldArguments().get(0).name().identifier() ));
+			input.statements_roles.add(new World( new Universe(), vd.type().get().worldArguments().get(0).name().identifier() ));
 
 			if( !vd.initializer().isPresent() ){
 				input.statements.add( variable );

--- a/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/GenerateMiniZincInputs.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/GenerateMiniZincInputs.java
@@ -28,73 +28,77 @@ import choral.utils.Pair;
  */
 public class GenerateMiniZincInputs {
 
-	Map<HigherCallable, MiniZincInput> allInputs = new HashMap<>();
+	Map< HigherCallable, MiniZincInput > allInputs = new HashMap<>();
 
-    public GenerateMiniZincInputs(){}
+	public GenerateMiniZincInputs() {
+	}
 
-    public Map<HigherCallable, MiniZincInput> generateInputs( CompilationUnit cu ){
-		
+	public Map< HigherCallable, MiniZincInput > generateInputs( CompilationUnit cu ) {
+
 		// Generate the MiniZinc inputs from the CompilationUnit
-		buildMiniZincInput(cu);
+		buildMiniZincInput( cu );
 
 		return allInputs;
 	}
 
-    /** 
+	/** 
 	 * Generates a MiniZinc input for all the methods in the CompilationUnit. These inputs are
 	 * stored in the allInputs map.
 	 */
-	private void buildMiniZincInput( CompilationUnit cu ){
-		for( Pair<HigherCallable, Statement> methodPair : Utils.getMethods(cu) ){
+	private void buildMiniZincInput( CompilationUnit cu ) {
+		for( Pair< HigherCallable, Statement > methodPair : Utils.getMethods( cu ) ) {
 			HigherCallable method = methodPair.left();
 			Statement methodStatement = methodPair.right();
 
 			//* maps an expression to the index of the dependency it belongs to */
-			Map<Expression, Integer> dependencyExpressions = new HashMap<>();
+			Map< Expression, Integer > dependencyExpressions = new HashMap<>();
 
 			MiniZincInput input = new MiniZincInput();
-			
-			for( Entry<World, List<Pair<Expression, Statement>>> dependencySet : method.worldDependencies().entrySet() ){    
+
+			for( Entry< World, List< Pair< Expression, Statement > > > dependencySet : method
+					.worldDependencies().entrySet() ) {
 				World recipient = dependencySet.getKey();
-				
-				for( Pair<Expression, Statement> dependencyPair : dependencySet.getValue() ){
+
+				for( Pair< Expression, Statement > dependencyPair : dependencySet.getValue() ) {
 					Expression dependencyExpression = dependencyPair.left();
 
 					// Extract sender from dependency (what world needs to send data)
-					World sender = getSender(dependencyExpression);
+					World sender = getSender( dependencyExpression );
 
 					// create Dependency object and find a valid channel
-					MiniZincInput.Dependency dependency = new MiniZincInput.Dependency(dependencyExpression, sender, recipient);
-					dependency.setComMethod(method.channels());
+					MiniZincInput.Dependency dependency =
+							new MiniZincInput.Dependency( dependencyExpression, sender, recipient );
+					dependency.setComMethod( method.channels() );
 
-					
-                    // add dependency to MiniZinc input
+
+					// add dependency to MiniZinc input
 					// unless the dependency already exists
-					if( !isDuplicateDependency( dependencyExpression, dependencyExpressions ) ){
-						input.num_deps ++;
-						input.dependencies.add(dependency);
-						dependencyExpressions.put(dependencyExpression, input.num_deps);
-						input.dependencyStrings.add(dependencyExpression.toString());
-						input.dep_from.add(sender);
-						input.dep_to.add(recipient);
+					if( !isDuplicateDependency( dependencyExpression, dependencyExpressions ) ) {
+						input.num_deps++;
+						input.dependencies.add( dependency );
+						dependencyExpressions.put( dependencyExpression, input.num_deps );
+						input.dependencyStrings.add( dependencyExpression.toString() );
+						input.dep_from.add( sender );
+						input.dep_to.add( recipient );
 						input.dep_def_at.add( 0 );
 					}
-                    
+
 				}
 			}
-			
+
 
 			// Add everything else to the MiniZinc input
-			input.num_blocks ++;
-			input.blocks.add(new MiniZincInput.Block(0, 0, 0)); // global block
+			input.num_blocks++;
+			input.blocks.add( new MiniZincInput.Block( 0, 0, 0 ) ); // global block
 
-			new VisitStatement( input, dependencyExpressions ).visitContinutation(methodStatement); // visit method body
-			input.blocks.get(0).end = input.in_size; // set end of global block
+			new VisitStatement( input, dependencyExpressions )
+					.visitContinutation( methodStatement ); // visit method body
+			input.blocks.get( 0 ).end = input.in_size; // set end of global block
 
-			List<World> worlds = cu.classes().stream() // collect all roles in method
-				.flatMap( cls -> cls.worldParameters().stream() )
-				.map( formalWorld -> (World)formalWorld.typeAnnotation().get() )
-				.toList();
+			List< World > worlds = cu.classes().stream() // collect all roles in method
+					.flatMap( cls -> cls.worldParameters().stream() )
+					.map( formalWorld -> (World) formalWorld.typeAnnotation().get() )
+					.toList();
 			input.roles = worlds;
 
 			allInputs.put( method, input );
@@ -104,64 +108,71 @@ public class GenerateMiniZincInputs {
 	/**
 	 * Checks whether or not the target expression is already a dependency.
 	 */
-	private boolean isDuplicateDependency( 
-		Expression target, 
-		Map<Expression, Integer> allExpressions
-	){
-		for( Expression otherExpression : allExpressions.keySet() ){
+	private boolean isDuplicateDependency(
+			Expression target,
+			Map< Expression, Integer > allExpressions
+	) {
+		for( Expression otherExpression : allExpressions.keySet() ) {
 			// try to merge target with otherExpression. If success, then target is a duplicate of 
 			// otherExpression. If failure, then target is not a duplicate of otherExpression
-			try { 
-				ExpressionsMerger.mergeExpressions(target, otherExpression);
+			try {
+				ExpressionsMerger.mergeExpressions( target, otherExpression );
 
 				// add target to allExpressions and map it to the dependency it is a duplicate of
-				allExpressions.put(target, allExpressions.get(otherExpression));
+				allExpressions.put( target, allExpressions.get( otherExpression ) );
 				return true;
 
-			} catch (Exception e) { }
+			} catch( Exception e ) {
+			}
 		}
 		// if all merges fail then target is not a duplicate
 		return false;
 	}
 
-    /**
+	/**
 	 * Returns the world from a dependency expression that needs to send data. If the 
 	 * dependency expression has more than one sender world an error is thrown.
 	 * <p>
 	 * If the dependency expression is a method call, the type-annotation is set to 
 	 * be equal to the method annotation.
 	 */
-	private World getSender( Expression dependencyExpression ){
+	private World getSender( Expression dependencyExpression ) {
 		// Extract senders from dependency (what world(s) needs to send data)
-		List<? extends World> senders;
-		if( dependencyExpression instanceof MethodCallExpression ){
+		List< ? extends World > senders;
+		if( dependencyExpression instanceof MethodCallExpression ) {
 			// MethodCallExpressions don't use typeAnnotation but instead use methodAnnotation
-			GroundDataType methodReturnType = (GroundDataType)((MethodCallExpression)dependencyExpression).methodAnnotation().get().returnType();
+			GroundDataType methodReturnType =
+					(GroundDataType) ( (MethodCallExpression) dependencyExpression )
+							.methodAnnotation().get().returnType();
 			// Set typeannotation = returntype here for more easy access to an expression's type
-			dependencyExpression.setTypeAnnotation(methodReturnType); 
+			dependencyExpression.setTypeAnnotation( methodReturnType );
 			senders = methodReturnType.worldArguments();
 		} else {
-			senders = ((GroundDataType)dependencyExpression.typeAnnotation().get()).worldArguments();
+			senders = ( (GroundDataType) dependencyExpression.typeAnnotation().get() )
+					.worldArguments();
 		}
-		
-		if( senders.size() != 1 ){
+
+		if( senders.size() != 1 ) {
 			// We don't accept dependencies with multiple sender worlds
-			throw new CommunicationInferenceException( "Found Dependency with " + senders.size() + " senders, expected 1" );
+			throw new CommunicationInferenceException(
+					"Found Dependency with " + senders.size() + " senders, expected 1" );
 		}
-		return senders.get(0);
+		return senders.get( 0 );
 	}
 
 	/**
 	 * Populates the given MiniZinc input. Also visits all expressions.
 	 */
-	private class VisitStatement extends AbstractChoralVisitor< Void >{
-		
+	private class VisitStatement extends AbstractChoralVisitor< Void > {
+
 		MiniZincInput input;
 		int currentBlock;
 		Map< Expression, Integer > dependencyExpressions;
 		Map< String, Integer > variableDefinedAt = new HashMap<>();
-		
-		public VisitStatement( MiniZincInput input, Map< Expression, Integer > dependencyExpressions ){
+
+		public VisitStatement(
+				MiniZincInput input, Map< Expression, Integer > dependencyExpressions
+		) {
 			this.input = input;
 			this.currentBlock = input.num_blocks;
 			this.dependencyExpressions = dependencyExpressions;
@@ -174,206 +185,214 @@ public class GenerateMiniZincInputs {
 
 		@Override
 		public Void visit( ExpressionStatement n ) {
-			input.in_size ++;
-			input.statements.add(n.expression().toString());
-			input.statements_blocks.add(currentBlock);
-			input.statements_roles.add(getWorld(n.expression()));
-			input.statementIndices.put(n, List.of(input.in_size));
+			input.in_size++;
+			input.statements.add( n.expression().toString() );
+			input.statements_blocks.add( currentBlock );
+			input.statements_roles.add( getWorld( n.expression() ) );
+			input.statementIndices.put( n, List.of( input.in_size ) );
 
-			
-			visitExpression(n.expression(), n);
-			
-			return visitContinutation(n.continuation());
+
+			visitExpression( n.expression(), n );
+
+			return visitContinutation( n.continuation() );
 		}
 
 		@Override
 		public Void visit( VariableDeclarationStatement n ) {
-			List<Integer> indices = new ArrayList<>();
-			
-			for( VariableDeclaration v : n.variables() ){
+			List< Integer > indices = new ArrayList<>();
+
+			for( VariableDeclaration v : n.variables() ) {
 				visitVariableDeclaration( v, n );
-				indices.add(input.in_size);
+				indices.add( input.in_size );
 			}
-			input.statementIndices.put(n, indices);
-			return visitContinutation(n.continuation());
+			input.statementIndices.put( n, indices );
+			return visitContinutation( n.continuation() );
 		}
 
 		@Override
 		public Void visit( NilStatement n ) {
-			return visitContinutation(n.continuation());
+			return visitContinutation( n.continuation() );
 		}
 
 		@Override
 		public Void visit( BlockStatement n ) {
-			List<Integer> indices = new ArrayList<>();
-			input.in_size ++;
-			input.statements.add("{");
-			input.statements_blocks.add(currentBlock);
-			input.statements_roles.add(null);
-			indices.add(input.in_size);
+			List< Integer > indices = new ArrayList<>();
+			input.in_size++;
+			input.statements.add( "{" );
+			input.statements_blocks.add( currentBlock );
+			input.statements_roles.add( null );
+			indices.add( input.in_size );
 
 			int block_start = input.in_size;
 			int block_parent = currentBlock;
 
-			input.num_blocks ++;
+			input.num_blocks++;
 			currentBlock = input.num_blocks;
 
-			visitContinutation(n.enclosedStatement());
+			visitContinutation( n.enclosedStatement() );
 
-			input.in_size ++;
-			input.statements.add("}");
-			input.statements_blocks.add(currentBlock);
-			input.statements_roles.add(null);
-			indices.add(input.in_size);
+			input.in_size++;
+			input.statements.add( "}" );
+			input.statements_blocks.add( currentBlock );
+			input.statements_roles.add( null );
+			indices.add( input.in_size );
 
-			input.blocks.add(new MiniZincInput.Block(block_start, input.in_size, block_parent));
+			input.blocks.add( new MiniZincInput.Block( block_start, input.in_size, block_parent ) );
 			currentBlock = block_parent;
-			input.statementIndices.put(n, indices);
+			input.statementIndices.put( n, indices );
 
-			return visitContinutation(n.continuation());
+			return visitContinutation( n.continuation() );
 		}
 
 		@Override
 		public Void visit( IfStatement n ) {
-			List<Integer> indices = new ArrayList<>();
+			List< Integer > indices = new ArrayList<>();
 
 			// condition
-			input.in_size ++;
+			input.in_size++;
 			input.statements.add( "if(" + n.condition() + "){" );
-			input.statements_blocks.add(currentBlock);
-			World if_role = ((GroundDataType)n.condition().typeAnnotation().get()).worldArguments().get(0);
+			input.statements_blocks.add( currentBlock );
+			World if_role = ( (GroundDataType) n.condition().typeAnnotation().get() )
+					.worldArguments().get( 0 );
 			input.statements_roles.add( if_role );
-			indices.add(input.in_size);
+			indices.add( input.in_size );
 
-			visitExpression(n.condition(), n);
-			
+			visitExpression( n.condition(), n );
+
 			int if_parent = currentBlock;
 
 			// if-branch
 			int if_start = input.in_size;
 
-			input.num_blocks ++;
+			input.num_blocks++;
 			int then_block = input.num_blocks;
 			currentBlock = then_block;
 			// inserting the block into the list to make sure the index of the then-block matches "then_block"
-			input.blocks.add(new MiniZincInput.Block( if_start, 0, if_parent )); // the end of the block will be set later
+			input.blocks.add( new MiniZincInput.Block( if_start, 0, if_parent ) ); // the end of the block will be set later
 
-			visitContinutation(n.ifBranch());
+			visitContinutation( n.ifBranch() );
 
 			// adding the "} else {"
-			input.in_size ++;
+			input.in_size++;
 			input.statements.add( "} else {" );
-			input.statements_blocks.add(currentBlock);
-			input.statements_roles.add(null);
-			indices.add(input.in_size);
+			input.statements_blocks.add( currentBlock );
+			input.statements_roles.add( null );
+			indices.add( input.in_size );
 
-			input.blocks.get(then_block-1).end = input.in_size; // set the end of the then-block
+			input.blocks.get( then_block - 1 ).end = input.in_size; // set the end of the then-block
 
 			// else-branch
 			int else_start = input.in_size;
 
-			input.num_blocks ++;
+			input.num_blocks++;
 			int else_block = input.num_blocks;
 			currentBlock = else_block;
 			// inserting the block into the list to make sure the index of the else-block matches "else_block"
-			input.blocks.add(new MiniZincInput.Block(else_start, 0, if_parent)); // the end of the block will be set later
+			input.blocks.add( new MiniZincInput.Block( else_start, 0, if_parent ) ); // the end of the block will be set later
 
-			visitContinutation(n.elseBranch());
+			visitContinutation( n.elseBranch() );
 
 			// adding the final "}"
-			input.in_size ++;
-			input.statements.add("}");
-			input.statements_blocks.add(currentBlock);
-			input.statements_roles.add(null);
-			indices.add(input.in_size);
+			input.in_size++;
+			input.statements.add( "}" );
+			input.statements_blocks.add( currentBlock );
+			input.statements_roles.add( null );
+			indices.add( input.in_size );
 
-			input.blocks.get(else_block-1).end = input.in_size; // set the end of the else-block
+			input.blocks.get( else_block - 1 ).end = input.in_size; // set the end of the else-block
 			currentBlock = if_parent;
 
-			input.num_ifs ++;
-			input.if_roles.add(if_role);
-			input.if_blocks.add(new Pair<>(then_block, else_block));
-			input.statementIndices.put(n, indices);
-			return visitContinutation(n.continuation());
+			input.num_ifs++;
+			input.if_roles.add( if_role );
+			input.if_blocks.add( new Pair<>( then_block, else_block ) );
+			input.statementIndices.put( n, indices );
+			return visitContinutation( n.continuation() );
 		}
 
 		@Override // not supported
 		public Void visit( SwitchStatement n ) {
-			throw new UnsupportedOperationException("SwitchStatement not supported\n\tStatement at " + n.position().toString());
+			throw new UnsupportedOperationException(
+					"SwitchStatement not supported\n\tStatement at " + n.position().toString() );
 		}
 
 		@Override // not supported
 		public Void visit( TryCatchStatement n ) {
-			throw new UnsupportedOperationException("TryCatchStatement not supported\n\tStatement at " + n.position().toString());
+			throw new UnsupportedOperationException(
+					"TryCatchStatement not supported\n\tStatement at " + n.position().toString() );
 		}
 
 		@Override
 		public Void visit( ReturnStatement n ) {
-			input.in_size ++;
+			input.in_size++;
 			input.statements.add( "return " + n.returnExpression().toString() );
-			input.statements_blocks.add(currentBlock);
-			
-			input.statements_roles.add(((GroundDataType)n.returnExpression().typeAnnotation().get()).worldArguments().get(0));
+			input.statements_blocks.add( currentBlock );
 
-			input.statementIndices.put(n, List.of(input.in_size));
+			input.statements_roles
+					.add( ( (GroundDataType) n.returnExpression().typeAnnotation().get() )
+							.worldArguments().get( 0 ) );
 
-			input.blocks.get(currentBlock-1).returns = input.in_size;
-			
-			visitExpression(n.returnExpression(), n);
-			return visitContinutation(n.continuation());
+			input.statementIndices.put( n, List.of( input.in_size ) );
+
+			input.blocks.get( currentBlock - 1 ).returns = input.in_size;
+
+			visitExpression( n.returnExpression(), n );
+			return visitContinutation( n.continuation() );
 		}
 
 		/** 
 		 * Visits the continuation if there is one 
 		 */
-		private Void visitContinutation( Statement continutation ){
-			return continutation == null ? null : visit(continutation);
+		private Void visitContinutation( Statement continutation ) {
+			return continutation == null ? null : visit( continutation );
 		}
 
 		/**
 		 * Calls {@code VisitExpression} on the given {@Expression}
 		 */
-		private void visitExpression( Expression expression, Statement n ){
-			
-			new VisitExpression( input, dependencyExpressions, variableDefinedAt ).checkIfDependency(expression);
+		private void visitExpression( Expression expression, Statement n ) {
+
+			new VisitExpression( input, dependencyExpressions, variableDefinedAt )
+					.checkIfDependency( expression );
 		}
 
 		/**
 		 * Insert a variable declaration into the MiniZinc input. Also visits the initializer 
 		 * if there is one.
 		 */
-		private void visitVariableDeclaration( VariableDeclaration vd, Statement n ){
-			
-			String variable = vd.typeAnnotation().get() + " " + vd.name();
-			input.in_size ++;
-			
-			input.statements_blocks.add(currentBlock);
-			input.statements_roles.add(new World( new Universe(), vd.type().get().worldArguments().get(0).name().identifier() ));
+		private void visitVariableDeclaration( VariableDeclaration vd, Statement n ) {
 
-			if( !vd.initializer().isPresent() ){
+			String variable = vd.typeAnnotation().get() + " " + vd.name();
+			input.in_size++;
+
+			input.statements_blocks.add( currentBlock );
+			input.statements_roles.add( new World( new Universe(),
+					vd.type().get().worldArguments().get( 0 ).name().identifier() ) );
+
+			if( !vd.initializer().isPresent() ) {
 				input.statements.add( variable );
 				return;
 			}
 			input.statements.add( variable + " = " + vd.initializer().get() );
-			variableDefinedAt.put(vd.name().identifier(), input.in_size);
-			
-			visitExpression(vd.initializer().get(), n);
+			variableDefinedAt.put( vd.name().identifier(), input.in_size );
+
+			visitExpression( vd.initializer().get(), n );
 		}
 
 		/**
 		 * Returns the homeworld of an expression.
 		 */
-		private World getWorld( Expression e ){
+		private World getWorld( Expression e ) {
 			World w;
-			if( e instanceof MethodCallExpression ){
+			if( e instanceof MethodCallExpression ) {
 				MethodCallExpression me = (MethodCallExpression) e;
-				w = me.methodAnnotation().get().higherCallable().declarationContext().worldArguments().get(0);
+				w = me.methodAnnotation().get().higherCallable().declarationContext()
+						.worldArguments().get( 0 );
 			} else if( e instanceof ScopedExpression ) {
-				ScopedExpression s = (ScopedExpression)e;
+				ScopedExpression s = (ScopedExpression) e;
 				w = getWorld( s.scopedExpression() );
 			} else {
-				GroundDataType typeAnnotation = (GroundDataType)e.typeAnnotation().get();
-				w = typeAnnotation.worldArguments().get(0);
+				GroundDataType typeAnnotation = (GroundDataType) e.typeAnnotation().get();
+				w = typeAnnotation.worldArguments().get( 0 );
 			}
 			// System.out.println( "World for expression " + e  + " : " + w );
 			return w;
@@ -386,21 +405,21 @@ public class GenerateMiniZincInputs {
 	 * <p>
 	 * Should called through {@code checkIfDependency()}
 	 */
-	private class VisitExpression extends AbstractChoralVisitor< Void >{
-		
+	private class VisitExpression extends AbstractChoralVisitor< Void > {
+
 		/** Maps variable identifiers to the statement in which they are defined */
-		Map<String, Integer> variableDefinedAt;
+		Map< String, Integer > variableDefinedAt;
 		MiniZincInput input;
 		/** If an expression is a dependency, this map maps it to that dependency's index in the input */
 		Map< Expression, Integer > dependencyExpressions;
 		/** The current innermost dependency */
 		Expression innerDependency = null;
 
-		public VisitExpression( 
-			MiniZincInput input, 
-			Map< Expression, Integer > dependencyExpressions,
-			Map< String, Integer > variableDefinedAt
-		){
+		public VisitExpression(
+				MiniZincInput input,
+				Map< Expression, Integer > dependencyExpressions,
+				Map< String, Integer > variableDefinedAt
+		) {
 			this.input = input;
 			this.dependencyExpressions = dependencyExpressions;
 			this.variableDefinedAt = variableDefinedAt;
@@ -409,24 +428,26 @@ public class GenerateMiniZincInputs {
 		/**
 		 * Checks if the given Expression is a dependency, then visits that Expression
 		 */
-		public Void checkIfDependency( Expression n ){
-			Integer dependency = dependencyExpressions.get(n);
-			if( dependency == null ){
-				visit(n);
-			} else{
+		public Void checkIfDependency( Expression n ) {
+			Integer dependency = dependencyExpressions.get( n );
+			if( dependency == null ) {
+				visit( n );
+			} else {
 				Expression parentDependency = innerDependency;
-				if( innerDependency == null ){
-					MiniZincInput.Dep_use dep = new MiniZincInput.Dep_use(dependencyExpressions.get(n));
+				if( innerDependency == null ) {
+					MiniZincInput.Dep_use dep =
+							new MiniZincInput.Dep_use( dependencyExpressions.get( n ) );
 					dep.used_at = input.in_size;
-					input.dep_used_at.add(dep);
+					input.dep_used_at.add( dep );
 				} else {
-					MiniZincInput.Dep_use dep = new MiniZincInput.Dep_use(dependencyExpressions.get(n));
+					MiniZincInput.Dep_use dep =
+							new MiniZincInput.Dep_use( dependencyExpressions.get( n ) );
 					dep.nested_dependency = true;
-					dep.used_at = dependencyExpressions.get(innerDependency);
-					input.dep_used_at.add(dep);
+					dep.used_at = dependencyExpressions.get( innerDependency );
+					input.dep_used_at.add( dep );
 				}
 				innerDependency = n;
-				visit(n);
+				visit( n );
 				innerDependency = parentDependency;
 			}
 
@@ -440,50 +461,51 @@ public class GenerateMiniZincInputs {
 
 		@Override
 		public Void visit( ScopedExpression n ) {
-			checkIfDependency(n.scope());
-			checkIfDependency(n.scopedExpression());
-			
+			checkIfDependency( n.scope() );
+			checkIfDependency( n.scopedExpression() );
+
 			return null;
 		}
 
 		@Override
 		public Void visit( FieldAccessExpression n ) {
 			// If we are inside a dependency, then we need to set dep_def_at
-			if( innerDependency != null ){
-				Integer definedAt = variableDefinedAt.get(n.name().identifier());
+			if( innerDependency != null ) {
+				Integer definedAt = variableDefinedAt.get( n.name().identifier() );
 				if( definedAt != null )
-					input.dep_def_at.set(dependencyExpressions.get(innerDependency)-1, definedAt);
+					input.dep_def_at.set( dependencyExpressions.get( innerDependency ) - 1,
+							definedAt );
 			}
-			
+
 			return null;
 		}
 
 		@Override
 		public Void visit( MethodCallExpression n ) {
 			for( Expression e : n.arguments() )
-				checkIfDependency(e);
+				checkIfDependency( e );
 			return null;
 		}
-		
+
 		@Override
 		public Void visit( AssignExpression n ) {
-			checkIfDependency(n.value());
+			checkIfDependency( n.value() );
 			return null;
 		}
 
 		@Override
 		public Void visit( BinaryExpression n ) {
-			checkIfDependency(n.left());
-			checkIfDependency(n.right());
+			checkIfDependency( n.left() );
+			checkIfDependency( n.right() );
 			return null;
 		}
 
 		@Override
 		public Void visit( EnclosedExpression n ) {
-			checkIfDependency(n.nestedExpression());
+			checkIfDependency( n.nestedExpression() );
 			return null;
 		}
-		
+
 		@Override
 		public Void visit( StaticAccessExpression n ) {
 			return null;
@@ -492,24 +514,26 @@ public class GenerateMiniZincInputs {
 		@Override
 		public Void visit( ClassInstantiationExpression n ) {
 			for( Expression e : n.arguments() )
-				checkIfDependency(e);
+				checkIfDependency( e );
 			return null;
 		}
 
 		@Override
 		public Void visit( NotExpression n ) {
-			checkIfDependency(n.expression());
+			checkIfDependency( n.expression() );
 			return null;
 		}
 
 		@Override // not supported
 		public Void visit( ThisExpression n ) {
-			throw new UnsupportedOperationException("ThisExpression not supported\n\tExpression at " + n.position().toString());
+			throw new UnsupportedOperationException(
+					"ThisExpression not supported\n\tExpression at " + n.position().toString() );
 		}
 
 		@Override // not supported
 		public Void visit( SuperExpression n ) {
-			throw new UnsupportedOperationException("SuperExpression not supported\n\tExpression at " + n.position().toString());
+			throw new UnsupportedOperationException(
+					"SuperExpression not supported\n\tExpression at " + n.position().toString() );
 		}
 
 		@Override
@@ -539,17 +563,21 @@ public class GenerateMiniZincInputs {
 
 		@Override // not supported
 		public Void visit( TypeExpression n ) {
-			throw new UnsupportedOperationException("TypeExpression not supported\n\tExpression at " + n.position().toString());
+			throw new UnsupportedOperationException(
+					"TypeExpression not supported\n\tExpression at " + n.position().toString() );
 		}
 
 		@Override // not supported
-		public Void visit( BlankExpression n ){
-			throw new UnsupportedOperationException("BlankExpression not supported\n\tExpression at " + n.position().toString());
+		public Void visit( BlankExpression n ) {
+			throw new UnsupportedOperationException(
+					"BlankExpression not supported\n\tExpression at " + n.position().toString() );
 		}
 
 		@Override // not supported
-		public Void visit( EnumCaseInstantiationExpression n ){
-			throw new UnsupportedOperationException("EnumCaseInstantiationExpression not supported\n\tExpression at " + n.position().toString());
+		public Void visit( EnumCaseInstantiationExpression n ) {
+			throw new UnsupportedOperationException(
+					"EnumCaseInstantiationExpression not supported\n\tExpression at "
+							+ n.position().toString() );
 		}
 	}
 

--- a/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/MiniZincInput.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/MiniZincInput.java
@@ -1,7 +1,6 @@
 package choral.compiler.moveMeant.MiniZincInference;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,15 +13,13 @@ import choral.ast.expression.MethodCallExpression;
 import choral.ast.expression.ScopedExpression;
 import choral.ast.statement.Statement;
 import choral.ast.type.TypeExpression;
-import choral.ast.type.WorldArgument;
 import choral.exceptions.CommunicationInferenceException;
-import choral.types.GroundClass;
-import choral.types.GroundClassOrInterface;
+
 import choral.types.GroundDataType;
 import choral.types.GroundDataTypeOrVoid;
 import choral.types.GroundInterface;
 import choral.types.GroundReferenceType;
-import choral.types.GroundTypeParameter;
+
 import choral.types.Member.HigherMethod;
 import choral.types.World;
 import choral.utils.Formatting;
@@ -249,12 +246,8 @@ public class MiniZincInput {
 		 */
 		public Expression createComExpression( Expression visitedDependency ){
 
-			TypeExpression typeExpression;
-            if( originalExpression.typeAnnotation().get() instanceof GroundTypeParameter ){
-				typeExpression = getTypeExpression((GroundTypeParameter)originalExpression.typeAnnotation().get());
-            } else{ 
-				typeExpression = getTypeExpression((GroundClassOrInterface)originalExpression.typeAnnotation().get());
-			}
+			TypeExpression typeExpression = ( (GroundReferenceType) originalExpression
+					.typeAnnotation().get() ).unapplyWorlds().reify();
 
 			final List<Expression> arguments = List.of( visitedDependency );
 			final Name name = new Name(comMethod.identifier());
@@ -269,69 +262,15 @@ public class MiniZincInput {
 			return new ScopedExpression(scope, scopedExpression);
 		}
 
-		private TypeExpression getTypeExpression( GroundClassOrInterface type ){
-			return new TypeExpression(
-				new Name(type.typeConstructor().identifier()),
-				Collections.emptyList(), 
-				type.typeArguments().stream().map( typeArg -> getTypeExpression(typeArg.applyTo(type.worldArguments())) ).toList());
-		}
-
-		private TypeExpression getTypeExpression( GroundReferenceType type ){
-			if( type instanceof GroundClass ){ // I think this is only not true for primitive types, which cannot be communicated
-				GroundClass typeGC = (GroundClass)type;
-				return new TypeExpression(
-					new Name(typeGC.typeConstructor().identifier()),
-					Collections.emptyList(), 
-					typeGC.typeArguments().stream().map( typeArg -> getTypeExpression(typeArg.applyTo(type.worldArguments())) ).toList());
-			}
-			if( type instanceof GroundTypeParameter ){
-				GroundTypeParameter typeGTP = (GroundTypeParameter)type;
-				return new TypeExpression(
-					new Name(typeGTP.typeConstructor().identifier()),
-					Collections.emptyList(), 
-					Collections.emptyList());
-			}
-			
-			throw new CommunicationInferenceException( "ERROR! Not a GroundClass or GroundTypeParameter. Found " + type.getClass() ); 
-		}
 
         /**
          * returns the type of the dependency's original expression as a TypeExpression
          * @return
          */
         public TypeExpression getType(){
-            if( originalExpression.typeAnnotation().get() instanceof GroundTypeParameter ){
-				return getType((GroundTypeParameter)originalExpression.typeAnnotation().get());
-            } else{ 
-				return getType((GroundClassOrInterface)originalExpression.typeAnnotation().get());
-			}
+			return ( (GroundReferenceType) originalExpression
+					.typeAnnotation().get() ).unapplyWorlds().reify();
         }
-
-        private TypeExpression getType( GroundClassOrInterface type ){
-            return new TypeExpression(
-				new Name(type.typeConstructor().identifier()),
-				List.of( new WorldArgument(new Name(recipient.identifier()), null) ), 
-				type.typeArguments().stream().map( typeArg -> getTypeExpression(typeArg.applyTo(type.worldArguments())) ).toList());
-		}
-
-		private TypeExpression getType( GroundReferenceType type ){
-            if( type instanceof GroundClass ){ // I think this is only not true for primitive types, which cannot be communicated
-				GroundClass typeGC = (GroundClass)type;
-				return new TypeExpression(
-					new Name(typeGC.typeConstructor().identifier()),
-					List.of( new WorldArgument(new Name(recipient.identifier()), null) ), 
-					typeGC.typeArguments().stream().map( typeArg -> getTypeExpression(typeArg.applyTo(type.worldArguments())) ).toList());
-			}
-			if( type instanceof GroundTypeParameter ){
-				GroundTypeParameter typeGTP = (GroundTypeParameter)type;
-				return new TypeExpression(
-					new Name(typeGTP.typeConstructor().identifier()),
-					List.of( new WorldArgument(new Name(recipient.identifier()), null) ), 
-					Collections.emptyList());
-			}
-			
-			throw new CommunicationInferenceException( "ERROR! Not a GroundClass or GroundTypeParameter. Found " + type.getClass() ); 
-		}
 
     /**
 	 * Find and set a valid channel and communication method.

--- a/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/MiniZincInput.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/MiniZincInference/MiniZincInput.java
@@ -31,187 +31,191 @@ import choral.utils.Pair;
  * Generate the input as a string using {@code toString()}
  */
 public class MiniZincInput {
-    public int in_size = 0;
-    public List<String> statements = new ArrayList<>();
-    public List<World> statements_roles = new ArrayList<>();
-    public List<Integer> statements_blocks = new ArrayList<>();
+	public int in_size = 0;
+	public List< String > statements = new ArrayList<>();
+	public List< World > statements_roles = new ArrayList<>();
+	public List< Integer > statements_blocks = new ArrayList<>();
 
-    public int num_blocks = 0;
-    public List<Block> blocks = new ArrayList<>();
-    
-    public List<World> roles = new ArrayList<>();
+	public int num_blocks = 0;
+	public List< Block > blocks = new ArrayList<>();
 
-    public int num_ifs = 0;
-    public List<Pair<Integer,Integer>> if_blocks = new ArrayList<>();
-    public List<World> if_roles = new ArrayList<>();
+	public List< World > roles = new ArrayList<>();
 
-    public int num_deps = 0;
-    public List<String> dependencyStrings = new ArrayList<>();
-    public List<World> dep_from = new ArrayList<>();
-    public List<World> dep_to = new ArrayList<>();
-    public List<Integer> dep_def_at = new ArrayList<>();
-    public List<Dep_use> dep_used_at = new ArrayList<>();
+	public int num_ifs = 0;
+	public List< Pair< Integer, Integer > > if_blocks = new ArrayList<>();
+	public List< World > if_roles = new ArrayList<>();
 
-    public List<Dependency> dependencies = new ArrayList<>();
-    public Map<Statement, List<Integer>> statementIndices = new HashMap<>();
+	public int num_deps = 0;
+	public List< String > dependencyStrings = new ArrayList<>();
+	public List< World > dep_from = new ArrayList<>();
+	public List< World > dep_to = new ArrayList<>();
+	public List< Integer > dep_def_at = new ArrayList<>();
+	public List< Dep_use > dep_used_at = new ArrayList<>();
 
-    public String toString(){
-        String inputString = "";
+	public List< Dependency > dependencies = new ArrayList<>();
+	public Map< Statement, List< Integer > > statementIndices = new HashMap<>();
 
-        inputString += "in_size = " + in_size + ";\n";
-        inputString += "statements = ";
-        inputString += statements.stream()
-            .map( stm -> "\"" + stm + "\"" )
-            .collect(Formatting.joining(",\n", "[\n", "];", "[];"));
-        inputString += "\n";
-        inputString += "statements_roles = ";
-        inputString += statements_roles.stream()
-            .map( r -> r == null ? "NULL" : "r(" + r.identifier() + ")" )
-            .collect(Formatting.joining(",", "[", "];", "[];"));
-        inputString += "\n";
+	public String toString() {
+		String inputString = "";
 
-        inputString += "num_blocks = " + num_blocks + ";\n";
-        inputString += "blocks = ";
-        inputString += blocks.stream()
-            .map( block -> (block.start) + "," + (block.end) + "," + (block.parent) )
-            .collect(Formatting.joining("|\n", "[|\n", "|];", "[];"));
-        inputString += "\n";
-		inputString += "block_returns = ";
-        inputString += blocks.stream()
-            .map( block -> 
-				(block.returns == null) ? 
-					"blocks[" + (blocks.indexOf(block)+1) + ",2]" : 
-					block.returns.toString() )
-            .collect(Formatting.joining(",", "[", "];", "[];"));
+		inputString += "in_size = " + in_size + ";\n";
+		inputString += "statements = ";
+		inputString += statements.stream()
+				.map( stm -> "\"" + stm + "\"" )
+				.collect( Formatting.joining( ",\n", "[\n", "];", "[];" ) );
+		inputString += "\n";
+		inputString += "statements_roles = ";
+		inputString += statements_roles.stream()
+				.map( r -> r == null ? "NULL" : "r(" + r.identifier() + ")" )
+				.collect( Formatting.joining( ",", "[", "];", "[];" ) );
 		inputString += "\n";
 
-        inputString += "statements_blocks = ";
-        inputString += statements_blocks.stream()
-            .map( i -> i.toString() )
-            .collect(Formatting.joining(",", "[", "];", "[];"));
-        inputString += "\n";
+		inputString += "num_blocks = " + num_blocks + ";\n";
+		inputString += "blocks = ";
+		inputString += blocks.stream()
+				.map( block -> ( block.start ) + "," + ( block.end ) + "," + ( block.parent ) )
+				.collect( Formatting.joining( "|\n", "[|\n", "|];", "[];" ) );
+		inputString += "\n";
+		inputString += "block_returns = ";
+		inputString += blocks.stream()
+				.map( block -> ( block.returns == null ) ?
+						"blocks[" + ( blocks.indexOf( block ) + 1 ) + ",2]" :
+						block.returns.toString() )
+				.collect( Formatting.joining( ",", "[", "];", "[];" ) );
+		inputString += "\n";
 
-        inputString += "num_ifs = " + num_ifs + ";\n";
-        inputString += "if_blocks = ";
-        inputString += if_blocks.stream()
-            .map( blocks -> blocks.left() + "," + blocks.right() )
-            .collect(Formatting.joining("|\n", "[|\n", "|];", "[];"));
-        inputString += "\n";
-        inputString += "if_roles = ";
-        inputString += if_roles.stream()
-            .map( role -> role.identifier() )
-            .collect(Formatting.joining(",", "[", "];", "[];"));
-        inputString += "\n";
+		inputString += "statements_blocks = ";
+		inputString += statements_blocks.stream()
+				.map( i -> i.toString() )
+				.collect( Formatting.joining( ",", "[", "];", "[];" ) );
+		inputString += "\n";
 
-        inputString += "roles = ";
-        inputString += roles.stream()
-            .map( role -> role.identifier() )
-            .collect(Formatting.joining(",", "{", "};", "{};"));
-        inputString += "\n";
-        
-        inputString += "num_deps = " + num_deps + ";\n";
-        inputString += "dependencies = ";
-        inputString += dependencyStrings.stream()
-            .map( dep -> "\"" + dep + "\"" )
-            .collect(Formatting.joining(",", "array1d( DEPS, [", "]);", "array1d( DEPS, []);"));
-        inputString += "\n";
-        inputString += "dep_from = ";
-        inputString += dep_from.stream()
-            .map( role -> role.identifier() )
-            .collect(Formatting.joining(",", "array1d( DEPS, [", "]);", "array1d( DEPS, []);"));
-        inputString += "\n";
-        inputString += "dep_to = ";
-        inputString += dep_to.stream()
-            .map( role -> role.identifier() )
-            .collect(Formatting.joining(",", "array1d( DEPS, [", "]);", "array1d( DEPS, []);"));
-        inputString += "\n";
-        inputString += "dep_def_at = ";
-        inputString += dep_def_at.stream()
-            .map( i -> i.toString() )
-            .collect(Formatting.joining(",", "array1d( DEPS, [", "]);", "array1d( DEPS, []);"));
-        inputString += "\n";
-        inputString += "dep_used_at = ";
-        inputString += dep_used_at.stream()
-            .map( dep_use -> "DEPS[" + dep_use.dependency + "], " + 
-                (dep_use.nested_dependency ? 
-                    "DEPS[" + (dep_use.used_at) + "]":
-                    (dep_use.used_at)) )
-            .collect(Formatting.joining("|\n", "[|\n", "|];", "[];"));
-        inputString += "\n";
-        
+		inputString += "num_ifs = " + num_ifs + ";\n";
+		inputString += "if_blocks = ";
+		inputString += if_blocks.stream()
+				.map( blocks -> blocks.left() + "," + blocks.right() )
+				.collect( Formatting.joining( "|\n", "[|\n", "|];", "[];" ) );
+		inputString += "\n";
+		inputString += "if_roles = ";
+		inputString += if_roles.stream()
+				.map( role -> role.identifier() )
+				.collect( Formatting.joining( ",", "[", "];", "[];" ) );
+		inputString += "\n";
 
-        return inputString;
-    }
+		inputString += "roles = ";
+		inputString += roles.stream()
+				.map( role -> role.identifier() )
+				.collect( Formatting.joining( ",", "{", "};", "{};" ) );
+		inputString += "\n";
 
-    public static class Block{
-        int start;
-        int end;
-        int parent;
+		inputString += "num_deps = " + num_deps + ";\n";
+		inputString += "dependencies = ";
+		inputString += dependencyStrings.stream()
+				.map( dep -> "\"" + dep + "\"" )
+				.collect( Formatting.joining( ",", "array1d( DEPS, [", "]);",
+						"array1d( DEPS, []);" ) );
+		inputString += "\n";
+		inputString += "dep_from = ";
+		inputString += dep_from.stream()
+				.map( role -> role.identifier() )
+				.collect( Formatting.joining( ",", "array1d( DEPS, [", "]);",
+						"array1d( DEPS, []);" ) );
+		inputString += "\n";
+		inputString += "dep_to = ";
+		inputString += dep_to.stream()
+				.map( role -> role.identifier() )
+				.collect( Formatting.joining( ",", "array1d( DEPS, [", "]);",
+						"array1d( DEPS, []);" ) );
+		inputString += "\n";
+		inputString += "dep_def_at = ";
+		inputString += dep_def_at.stream()
+				.map( i -> i.toString() )
+				.collect( Formatting.joining( ",", "array1d( DEPS, [", "]);",
+						"array1d( DEPS, []);" ) );
+		inputString += "\n";
+		inputString += "dep_used_at = ";
+		inputString += dep_used_at.stream()
+				.map( dep_use -> "DEPS[" + dep_use.dependency + "], " +
+						( dep_use.nested_dependency ?
+								"DEPS[" + ( dep_use.used_at ) + "]" :
+								( dep_use.used_at ) ) )
+				.collect( Formatting.joining( "|\n", "[|\n", "|];", "[];" ) );
+		inputString += "\n";
+
+
+		return inputString;
+	}
+
+	public static class Block {
+		int start;
+		int end;
+		int parent;
 		Integer returns = null;
-        
-        public Block( int start, int end, int parent ){
-            this.start = start;
-            this.end = end;
-            this.parent = parent;
-        }
-        
-    }
 
-    public static class Dep_use{
-        int dependency;
-        int used_at;
-        boolean nested_dependency = false;
+		public Block( int start, int end, int parent ) {
+			this.start = start;
+			this.end = end;
+			this.parent = parent;
+		}
 
-        
-        public Dep_use( int dep ){
-            this.dependency = dep;
-        }
-    }
+	}
 
-    public static class Dependency{
+	public static class Dep_use {
+		int dependency;
+		int used_at;
+		boolean nested_dependency = false;
+
+
+		public Dep_use( int dep ) {
+			this.dependency = dep;
+		}
+	}
+
+	public static class Dependency {
 		private Expression originalExpression;
 		private HigherMethod comMethod;
 		private String channelIdentifier;
 		private GroundInterface channel;
 		private GroundDataType type;
-        private World sender;
-        private World recipient;
+		private World sender;
+		private World recipient;
 
-		public Dependency( Expression originalExpression, World sender, World recipient ){
+		public Dependency( Expression originalExpression, World sender, World recipient ) {
 			this.originalExpression = originalExpression;
 			GroundDataTypeOrVoid t = originalExpression.typeAnnotation().get();
 			if( t.isVoid() )
-				throw new CommunicationInferenceException( "Dependency cannot be of type void: " + originalExpression );
-			this.type = (GroundDataType)t;
+				throw new CommunicationInferenceException(
+						"Dependency cannot be of type void: " + originalExpression );
+			this.type = (GroundDataType) t;
 			this.recipient = recipient;
 			this.sender = sender;
 		}
 
-		public Expression originalExpression(){
+		public Expression originalExpression() {
 			return originalExpression;
 		}
 
-		public GroundDataType type(){
+		public GroundDataType type() {
 			return type;
 		}
 
-		public HigherMethod comMethod(){
+		public HigherMethod comMethod() {
 			return comMethod;
 		}
 
-		public String channelIdentifier(){
+		public String channelIdentifier() {
 			return channelIdentifier;
 		}
 
-		public GroundInterface channel(){
+		public GroundInterface channel() {
 			return channel;
 		}
 
-        public World recipient(){
+		public World recipient() {
 			return recipient;
 		}
 
-		public World sender(){
+		public World sender() {
 			return sender;
 		}
 
@@ -244,68 +248,78 @@ public class MiniZincInput {
 		 * @param visitedDependency - Must be visited before calling this method, 
 		 * 		otherwise nested dependencies will not be caught.
 		 */
-		public Expression createComExpression( Expression visitedDependency ){
+		public Expression createComExpression( Expression visitedDependency ) {
 
 			TypeExpression typeExpression = ( (GroundReferenceType) originalExpression
 					.typeAnnotation().get() ).unapplyWorlds().reify();
 
-			final List<Expression> arguments = List.of( visitedDependency );
-			final Name name = new Name(comMethod.identifier());
-			final List<TypeExpression> typeArguments = List.of( typeExpression );
-			
-			MethodCallExpression scopedExpression = new MethodCallExpression(name, arguments, typeArguments, visitedDependency.position());
-			
+			final List< Expression > arguments = List.of( visitedDependency );
+			final Name name = new Name( comMethod.identifier() );
+			final List< TypeExpression > typeArguments = List.of( typeExpression );
+
+			MethodCallExpression scopedExpression = new MethodCallExpression( name, arguments,
+					typeArguments, visitedDependency.position() );
+
 			// The comMethod is a method inside a channel, so we need to make the channel its scope
-			FieldAccessExpression scope = new FieldAccessExpression(new Name(channelIdentifier), visitedDependency.position());
-			
+			FieldAccessExpression scope = new FieldAccessExpression( new Name( channelIdentifier ),
+					visitedDependency.position() );
+
 			// Something like channel.< Type >com( visitedDependency )
-			return new ScopedExpression(scope, scopedExpression);
+			return new ScopedExpression( scope, scopedExpression );
 		}
 
 
-        /**
-         * returns the type of the dependency's original expression as a TypeExpression
-         * @return
-         */
-        public TypeExpression getType(){
+		/**
+		 * returns the type of the dependency's original expression as a TypeExpression
+		 * @return
+		 */
+		public TypeExpression getType() {
 			return ( (GroundReferenceType) originalExpression
 					.typeAnnotation().get() ).unapplyWorlds().reify();
-        }
+		}
 
-    /**
-	 * Find and set a valid channel and communication method.
-	 * <p>
-	 * If no viable channel can be found, an exception is thrown.
-	 */
-	public void setComMethod(List<Pair<String, GroundInterface>> channels){
-		
-		for( Pair<String, GroundInterface> channelPair : channels ){
+		/**
+		 * Find and set a valid channel and communication method.
+		 * <p>
+		 * If no viable channel can be found, an exception is thrown.
+		 */
+		public void setComMethod( List< Pair< String, GroundInterface > > channels ) {
 
-			// Data channels might not return the same datatype at the receiver as 
-			// the datatype from the sender. Since we only store one type for the 
-			// dependency we assume that all types in a channel are the same.
-			GroundInterface channel = channelPair.right();
-			if( channel.typeArguments().stream().anyMatch( typeArg -> type.typeConstructor().isSubtypeOf( typeArg ) ) ){
-				
-				Optional<? extends HigherMethod> comMethodOptional = 
-					channelPair.right().methods()
-						.filter( method ->
-							method.identifier().equals("com") && // it is a com method (only checked through name)
-							method.innerCallable().signature().parameters().get(0).type().worldArguments().equals(List.of(sender)) && // its parameter's worlds are equal to our dependency's world(s)
-							method.innerCallable().returnType() instanceof GroundDataType && // probably redundant check, returntype should not be able to be void
-							((GroundDataType)method.innerCallable().returnType()).worldArguments().get(0).equals(recipient) ) // its returntype's world is equal to our dependency recipient
-						.findAny();
-				
-				if( comMethodOptional.isPresent() ){
-					channelIdentifier = channelPair.left();
-			        this.channel = channel;
-                    comMethod = comMethodOptional.get();
-					return;
+			for( Pair< String, GroundInterface > channelPair : channels ) {
+
+				// Data channels might not return the same datatype at the receiver as 
+				// the datatype from the sender. Since we only store one type for the 
+				// dependency we assume that all types in a channel are the same.
+				GroundInterface channel = channelPair.right();
+				if( channel.typeArguments().stream()
+						.anyMatch( typeArg -> type.typeConstructor().isSubtypeOf( typeArg ) ) ) {
+
+					Optional< ? extends HigherMethod > comMethodOptional =
+							channelPair.right().methods()
+									.filter( method -> method.identifier().equals( "com" ) && // it is a com method (only checked through name)
+											method.innerCallable().signature().parameters().get( 0 )
+													.type().worldArguments()
+													.equals( List.of( sender ) )
+											&& // its parameter's worlds are equal to our dependency's world(s)
+											method.innerCallable()
+													.returnType() instanceof GroundDataType
+											&& // probably redundant check, returntype should not be able to be void
+											( (GroundDataType) method.innerCallable().returnType() )
+													.worldArguments().get( 0 ).equals( recipient ) ) // its returntype's world is equal to our dependency recipient
+									.findAny();
+
+					if( comMethodOptional.isPresent() ) {
+						channelIdentifier = channelPair.left();
+						this.channel = channel;
+						comMethod = comMethodOptional.get();
+						return;
+					}
 				}
 			}
+			throw new CommunicationInferenceException(
+					"No viable communication method was found for the dependency "
+							+ originalExpression() );
 		}
-		throw new CommunicationInferenceException( "No viable communication method was found for the dependency " + originalExpression() );
-	}
 
 	}
 }

--- a/choral/src/main/java/choral/compiler/moveMeant/Normalizer.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/Normalizer.java
@@ -743,6 +743,6 @@ public class Normalizer {
 	 * temporaries.
 	 */
 	private static TypeExpression getType( GroundDataTypeOrVoid t ) {
-		return Utils.outerTypeExpression( (GroundDataType) box( t ) );
+		return ( (GroundDataType) box( t ) ).reify();
 	}
 }

--- a/choral/src/main/java/choral/compiler/moveMeant/Normalizer.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/Normalizer.java
@@ -281,13 +281,14 @@ public class Normalizer {
 					AssignExpression init = vd.initializer().get();
 					NormalizedExpr res =
 							init.accept( new VisitExpression(
-									(GroundDataTypeOrVoid) vd.type().typeAnnotation().orElseThrow(),
+									(GroundDataTypeOrVoid) vd.typeAnnotation().orElseThrow(),
 									context ) );
 					VariableDeclaration newVd = new VariableDeclaration(
 							vd.name(),
 							vd.type(),
 							vd.annotations(),
 							(AssignExpression) res.expression(),
+							
 							vd.position() );
 					exprs.add( res.first(), res.last(), newVd );
 				}

--- a/choral/src/main/java/choral/compiler/moveMeant/Normalizer.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/Normalizer.java
@@ -59,8 +59,8 @@ public class Normalizer {
 	 * for each rebuilt callable body, keyed by that callable's type annotation.
 	 */
 	public record Result(
-			CompilationUnit compilationUnit,
-			Map< Member.HigherCallable, List< VariableDeclaration > > hoistedDefinitions ) {
+						 CompilationUnit compilationUnit,
+						 Map< Member.HigherCallable, List< VariableDeclaration > > hoistedDefinitions) {
 	}
 
 	/**
@@ -119,9 +119,17 @@ public class Normalizer {
 			this.results.add( result );
 		}
 
-		Statement first() { return first; }
-		Statement last() { return last; }
-		List< T > results() { return results; }
+		Statement first() {
+			return first;
+		}
+
+		Statement last() {
+			return last;
+		}
+
+		List< T > results() {
+			return results;
+		}
 	}
 
 	private record HoistKey(Expression expression, List< String > expectedWorlds) {
@@ -207,7 +215,8 @@ public class Normalizer {
 							.accept( new VisitStatement(
 									method.signature().typeAnnotation().orElseThrow()
 											.innerCallable().returnType(),
-									context ) ).first();
+									context ) )
+							.first();
 				}
 				ClassMethodDefinition newMethod = new ClassMethodDefinition(
 						method.signature(),
@@ -288,7 +297,6 @@ public class Normalizer {
 							vd.type(),
 							vd.annotations(),
 							(AssignExpression) res.expression(),
-							
 							vd.position() );
 					exprs.add( res.first(), res.last(), newVd );
 				}
@@ -442,8 +450,10 @@ public class Normalizer {
 
 		@Override
 		public NormalizedExpr visit( BinaryExpression n ) {
-			NormalizedExpr l = n.left().accept( visitor( typeWithWorldsOf( n.left(), expectedType ) ) );
-			NormalizedExpr r = n.right().accept( visitor( typeWithWorldsOf( n.right(), expectedType ) ) );
+			NormalizedExpr l =
+					n.left().accept( visitor( typeWithWorldsOf( n.left(), expectedType ) ) );
+			NormalizedExpr r =
+					n.right().accept( visitor( typeWithWorldsOf( n.right(), expectedType ) ) );
 
 			var newArgs = new NormalizedResults< Expression >();
 			newArgs.add( l.first(), l.last(), l.expression() );
@@ -613,7 +623,8 @@ public class Normalizer {
 		 * continuation is left null.
 		 */
 		private VariableDeclarationStatement makeHoist(
-				Name msg, Expression expr, GroundDataTypeOrVoid expectedType ) {
+				Name msg, Expression expr, GroundDataTypeOrVoid expectedType
+		) {
 			FieldAccessExpression target = new FieldAccessExpression( msg, expr.position() );
 			target.setTypeAnnotation( expectedType );
 			AssignExpression initializer = new AssignExpression(
@@ -639,7 +650,8 @@ public class Normalizer {
 	}
 
 	private static FieldAccessExpression msgAccess(
-			Name msg, GroundDataTypeOrVoid type, Position position ) {
+			Name msg, GroundDataTypeOrVoid type, Position position
+	) {
 		FieldAccessExpression msgAccess = new FieldAccessExpression( msg, position );
 		msgAccess.setTypeAnnotation( type );
 		return msgAccess;
@@ -725,7 +737,8 @@ public class Normalizer {
 	}
 
 	private static GroundDataTypeOrVoid typeWithWorldsOf(
-			Expression typedLike, GroundDataTypeOrVoid worldSource ) {
+			Expression typedLike, GroundDataTypeOrVoid worldSource
+	) {
 		if( worldSource == null || worldSource.isVoid() ) return typeOf( typedLike );
 		GroundDataType type = (GroundDataType) typeOf( typedLike );
 		List< ? extends World > worlds = ( (GroundDataType) worldSource ).worldArguments();

--- a/choral/src/main/java/choral/compiler/moveMeant/Utils.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/Utils.java
@@ -5,24 +5,22 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import choral.ast.CompilationUnit;
-import choral.ast.Name;
+
 import choral.ast.expression.Expression;
 import choral.ast.statement.NilStatement;
 import choral.ast.statement.Statement;
-import choral.ast.type.TypeExpression;
-import choral.ast.type.WorldArgument;
+
 import choral.compiler.merge.ExpressionsMerger;
-import choral.types.GroundClassOrInterface;
+
 import choral.types.GroundDataType;
 import choral.types.GroundInterface;
-import choral.types.GroundTypeParameter;
+
 import choral.types.Member.HigherCallable;
 import choral.types.Member.HigherMethod;
 import choral.types.World;
 import choral.utils.Continuation;
 import choral.utils.Pair;
 
-import java.util.Collections;
 
 public class Utils {
 
@@ -155,53 +153,4 @@ public class Utils {
 		return chainStatements(statements, Continuation.continuationAfter(stm, last));
 	}
 
-	/**
-	 * Builds a {@link TypeExpression} for {@code t} at world-annotation position
-	 * (e.g. {@code T@W msg = ...}); the type's own world arguments are emitted on the
-	 * outermost level. Type arguments nested inside are rendered without world annotations
-	 * via {@link #innerTypeExpression}.
-	 */
-	public static TypeExpression outerTypeExpression( GroundDataType t ) {
-		List< WorldArgument > worldArgs = t.worldArguments().stream()
-				.map( w -> {
-					WorldArgument worldArgument =
-							new WorldArgument( new Name( w.identifier() ), null );
-					worldArgument.setTypeAnnotation( w );
-					return worldArgument;
-				} )
-				.toList();
-		return typeExpression( t, worldArgs );
-	}
-
-	/**
-	 * Builds a {@link TypeExpression} for {@code t} at type-argument position
-	 * (e.g. inside {@code Map< K, V >} or {@code ch.<T>com(...)}); world arguments are
-	 * omitted at every level.
-	 */
-	public static TypeExpression innerTypeExpression( GroundDataType t ) {
-		return typeExpression( t, Collections.emptyList() );
-	}
-
-	private static TypeExpression typeExpression(
-			GroundDataType t, List< WorldArgument > worldArgs ) {
-		if( t instanceof GroundClassOrInterface gc ) {
-			List< TypeExpression > typeArgs = gc.typeArguments().stream()
-					.map( ta -> innerTypeExpression( ta.applyTo( gc.worldArguments() ) ) )
-					.toList();
-			TypeExpression typeExpression = new TypeExpression(
-					new Name( gc.typeConstructor().identifier() ), worldArgs, typeArgs );
-			typeExpression.setTypeAnnotation( gc );
-			return typeExpression;
-		}
-		if( t instanceof GroundTypeParameter gtp ) {
-			TypeExpression typeExpression = new TypeExpression(
-					new Name( gtp.typeConstructor().identifier() ),
-					worldArgs,
-					Collections.emptyList() );
-			typeExpression.setTypeAnnotation( gtp );
-			return typeExpression;
-		}
-		throw new IllegalStateException(
-				"Unsupported type for type expression: " + t.getClass().getSimpleName() );
-	}
 }

--- a/choral/src/main/java/choral/compiler/moveMeant/Utils.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/Utils.java
@@ -24,29 +24,29 @@ import choral.utils.Pair;
 
 public class Utils {
 
-    /**
+	/**
 	 * Retreives all methods from the {@code CompilationUnit} including constructors.
-     * <p>
-     * Returns a List of Pair of the methods typeannotation and the first statement in its body.
+	 * <p>
+	 * Returns a List of Pair of the methods typeannotation and the first statement in its body.
 	 * <p>
 	 * filters out all methods that has no method body.
 	 */
-    public static List<Pair<HigherCallable, Statement>> getMethods( CompilationUnit cu ){
-		return Stream.concat( 
-			cu.classes().stream()
-				.flatMap( cls -> cls.methods().stream() )
-				.filter( method -> method.body().isPresent() && !(method.body().get() instanceof NilStatement) )
-				.map( method -> 
-					new Pair<HigherCallable, Statement>(
-						method.signature().typeAnnotation().get(), // we assume that methods are type-annotated
-						method.body().get()) ), 
-			cu.classes().stream()
-				.flatMap(cls -> cls.constructors().stream()
-				.map( method -> 
-					new Pair<HigherCallable, Statement>(
-						method.signature().typeAnnotation().get(), 
-						method.blockStatements()) )
-				)).toList();
+	public static List< Pair< HigherCallable, Statement > > getMethods( CompilationUnit cu ) {
+		return Stream.concat(
+				cu.classes().stream()
+						.flatMap( cls -> cls.methods().stream() )
+						.filter( method -> method.body().isPresent()
+								&& !( method.body().get() instanceof NilStatement ) )
+						.map( method -> new Pair< HigherCallable, Statement >(
+								method.signature().typeAnnotation().get(), // we assume that methods are type-annotated
+								method.body().get() ) ),
+				cu.classes().stream()
+						.flatMap( cls -> cls.constructors().stream()
+								.map( method -> new Pair< HigherCallable, Statement >(
+										method.signature().typeAnnotation().get(),
+										method.blockStatements() ) )
+						) )
+				.toList();
 	}
 
 	/**
@@ -62,37 +62,43 @@ public class Utils {
 	 * </ul>
 	 * Returns null if no such method is found.
 	 */
-	public static Pair<Pair<String, GroundInterface>, HigherMethod> findComMethod(
-		World recipient, 
-		World sender, 
-		GroundDataType dependencyType, 
-		List<Pair<String, GroundInterface>> channels){
-		
-		for( Pair<String, GroundInterface> channelPair : channels ){
+	public static Pair< Pair< String, GroundInterface >, HigherMethod > findComMethod(
+			World recipient,
+			World sender,
+			GroundDataType dependencyType,
+			List< Pair< String, GroundInterface > > channels
+	) {
+
+		for( Pair< String, GroundInterface > channelPair : channels ) {
 
 			// Data channels might not return the same datatype at the receiver as
 			// the datatype from the sender. Since we only store one type for the
 			// dependency we assume that all types in a channel are the same.
 			GroundInterface channel = channelPair.right();
-			if( channel.typeArguments().stream().anyMatch( typeArg -> dependencyType.typeConstructor().isSubtypeOf( typeArg ) ) ){
-				
-				Optional<? extends HigherMethod> comMethodOptional = 
-					channelPair.right().methods()
-						.filter( method ->
-							method.identifier().equals("com") && // it is a com method (only checked through name)
-							method.innerCallable().signature().parameters().get(0).type().worldArguments().equals(List.of(sender)) && // its parameter's worlds are equal to our dependency's world(s)
-							method.innerCallable().returnType() instanceof GroundDataType && // probably redundant check, returntype should not be able to be void
-							((GroundDataType)method.innerCallable().returnType()).worldArguments().get(0).equals(recipient) ) // its returntype's world is equal to our dependency recipient
-						.findAny();
-				
-				if( comMethodOptional.isPresent() ){
-					return new Pair<>( channelPair, comMethodOptional.get());
+			if( channel.typeArguments().stream().anyMatch(
+					typeArg -> dependencyType.typeConstructor().isSubtypeOf( typeArg ) ) ) {
+
+				Optional< ? extends HigherMethod > comMethodOptional =
+						channelPair.right().methods()
+								.filter( method -> method.identifier().equals( "com" ) && // it is a com method (only checked through name)
+										method.innerCallable().signature().parameters().get( 0 )
+												.type().worldArguments().equals( List.of( sender ) )
+										&& // its parameter's worlds are equal to our dependency's world(s)
+										method.innerCallable()
+												.returnType() instanceof GroundDataType
+										&& // probably redundant check, returntype should not be able to be void
+										( (GroundDataType) method.innerCallable().returnType() )
+												.worldArguments().get( 0 ).equals( recipient ) ) // its returntype's world is equal to our dependency recipient
+								.findAny();
+
+				if( comMethodOptional.isPresent() ) {
+					return new Pair<>( channelPair, comMethodOptional.get() );
 				}
 			}
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Searches through the methods of {@code channels} and returns the first viable selection 
 	 * method based on the input. 
@@ -106,24 +112,26 @@ public class Utils {
 	 * </ul>
 	 * Returns null if no such method is found.
 	 */
-	public static Pair<Pair<String, GroundInterface>, HigherMethod> findSelectionMethod(
-		World recipient, 
-		World sender, 
-		List<Pair<String, GroundInterface>> channels
-	){
-		for( Pair<String, GroundInterface> channelPair : channels ){
-            
-			Optional<? extends HigherMethod> selectMethodOptional = 
-				channelPair.right().methods()
-					.filter( method ->
-						method.identifier().equals("select") && // it is a selection method (only checked through name)
-						method.innerCallable().signature().parameters().get(0).type().worldArguments().equals(List.of(sender)) && // its parameter's worlds are equal to our sender
-						method.innerCallable().returnType() instanceof GroundDataType && // probably redundant check, returntype should not be able to be void
-						((GroundDataType)method.innerCallable().returnType()).worldArguments().get(0).equals(recipient) ) // its returntype's world is equal to our recipient
-					.findAny();
-		
-			if( selectMethodOptional.isPresent() ){
-				return new Pair<>(channelPair, selectMethodOptional.get());
+	public static Pair< Pair< String, GroundInterface >, HigherMethod > findSelectionMethod(
+			World recipient,
+			World sender,
+			List< Pair< String, GroundInterface > > channels
+	) {
+		for( Pair< String, GroundInterface > channelPair : channels ) {
+
+			Optional< ? extends HigherMethod > selectMethodOptional =
+					channelPair.right().methods()
+							.filter( method -> method.identifier().equals( "select" ) && // it is a selection method (only checked through name)
+									method.innerCallable().signature().parameters().get( 0 ).type()
+											.worldArguments().equals( List.of( sender ) )
+									&& // its parameter's worlds are equal to our sender
+									method.innerCallable().returnType() instanceof GroundDataType && // probably redundant check, returntype should not be able to be void
+									( (GroundDataType) method.innerCallable().returnType() )
+											.worldArguments().get( 0 ).equals( recipient ) ) // its returntype's world is equal to our recipient
+							.findAny();
+
+			if( selectMethodOptional.isPresent() ) {
+				return new Pair<>( channelPair, selectMethodOptional.get() );
 			}
 		}
 		// no viable selectionmethod was found
@@ -135,22 +143,22 @@ public class Utils {
 	 * <p>
 	 * Two expressions are equal if ExpressionsMerger can successfully merge them.
 	 */
-	public static boolean isSameExpression( Expression e1, Expression e2 ){
-		try { 
-			ExpressionsMerger.mergeExpressions(e1, e2);
+	public static boolean isSameExpression( Expression e1, Expression e2 ) {
+		try {
+			ExpressionsMerger.mergeExpressions( e1, e2 );
 			return true;
 
-		} catch (Exception e) {
+		} catch( Exception e ) {
 			return false;
 		}
 	}
 
-	public static Statement chainStatements( List<Statement> statements, Statement last ){
+	public static Statement chainStatements( List< Statement > statements, Statement last ) {
 		if( statements.size() == 0 )
 			return last;
 
-		Statement stm = statements.remove(statements.size()-1);
-		return chainStatements(statements, Continuation.continuationAfter(stm, last));
+		Statement stm = statements.remove( statements.size() - 1 );
+		return chainStatements( statements, Continuation.continuationAfter( stm, last ) );
 	}
 
 }

--- a/choral/src/main/java/choral/compiler/moveMeant/VariableReplacement.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/VariableReplacement.java
@@ -82,7 +82,7 @@ public class VariableReplacement {
 
 		// Build the communication expression
 		var methodType = comMethod.applyTo( List.of( inType.typeConstructor() ) );
-		var inTypeExpr = Utils.innerTypeExpression( inType );
+		var inTypeExpr = inType.unapplyWorlds().reify();
 
 		// The '<T>com( expr )' part
 		var scopedExpression = new MethodCallExpression( new Name( comMethod.identifier() ),

--- a/choral/src/main/java/choral/compiler/moveMeant/VariableReplacement.java
+++ b/choral/src/main/java/choral/compiler/moveMeant/VariableReplacement.java
@@ -71,10 +71,10 @@ public class VariableReplacement {
 		var comPair = Utils.findComMethod( receiver, sender, inType, callable.channels() );
 		if( comPair == null ) {
 			throw new AstPositionedException( hoist.position(),
-						new CommunicationInferenceException(
-								"No viable communication method from " + sender.identifier()
-										+ " to " + receiver.identifier()
-										+ " for type " + inType	) );
+					new CommunicationInferenceException(
+							"No viable communication method from " + sender.identifier()
+									+ " to " + receiver.identifier()
+									+ " for type " + inType ) );
 		}
 		var channelName = comPair.left().left();
 		var channelType = comPair.left().right();

--- a/choral/src/main/java/choral/compiler/soloist/DependencyVisitor.java
+++ b/choral/src/main/java/choral/compiler/soloist/DependencyVisitor.java
@@ -260,8 +260,8 @@ public class DependencyVisitor implements ChoralVisitorInterface< Void > {
 	public Void visit( TryCatchStatement n ) {
 		visit( n.body() );
 		n.catches().forEach( p -> {
-			if( p.left().type().worldArguments().contains( this.w ) ) {
-				visit( p.left().type() );
+			if( p.left().type().get().worldArguments().contains( this.w ) ) {
+				visit( p.left().type().get() );
 				visit( p.right() );
 			}
 		} );
@@ -459,7 +459,12 @@ public class DependencyVisitor implements ChoralVisitorInterface< Void > {
 
 	@Override
 	public Void visit( VariableDeclaration n ) {
-		visit( n.type() );
+	    if ( n.type().isPresent() ) {
+    		visit( n.type().get() );
+		}
+		else {
+		    visit( n.typeAnnotation().get().reify() );
+		}
 		n.initializer().ifPresent( this::visit );
 		return null;
 	}

--- a/choral/src/main/java/choral/compiler/soloist/DependencyVisitor.java
+++ b/choral/src/main/java/choral/compiler/soloist/DependencyVisitor.java
@@ -130,11 +130,11 @@ public class DependencyVisitor implements ChoralVisitorInterface< Void > {
 				.stream()
 				.filter( p -> !visitedTemplates.contains( p ) )
 				.forEach( p -> new DependencyVisitor(
-								availableTemplates,
-								projectableTemplates,
-								visitedTemplates,
-								getWorldFromIndex( availableTemplates.get( p.left() ).node(), p.right() )
-						).collectProjectableTemplates( p.left() )
+						availableTemplates,
+						projectableTemplates,
+						visitedTemplates,
+						getWorldFromIndex( availableTemplates.get( p.left() ).node(), p.right() )
+				).collectProjectableTemplates( p.left() )
 				);
 		// if we have fewer visited templates than projectable, we re-iterate
 		if( visitedTemplates.size() < projectableTemplates.size() ) {
@@ -459,11 +459,10 @@ public class DependencyVisitor implements ChoralVisitorInterface< Void > {
 
 	@Override
 	public Void visit( VariableDeclaration n ) {
-	    if ( n.type().isPresent() ) {
-    		visit( n.type().get() );
-		}
-		else {
-		    visit( n.typeAnnotation().get().reify() );
+		if( n.type().isPresent() ) {
+			visit( n.type().get() );
+		} else {
+			visit( n.typeAnnotation().get().reify() );
 		}
 		n.initializer().ifPresent( this::visit );
 		return null;
@@ -496,15 +495,13 @@ public class DependencyVisitor implements ChoralVisitorInterface< Void > {
 
 	@Override
 	public Void visit( FormalTypeParameter n ) {
-		n.worldParameters().forEach( w ->
-				n.upperBound().forEach( t ->
-						new DependencyVisitor(
-								this.availableTemplates,
-								this.projectableTemplates,
-								this.visitedTemplates,
-								w.toWorldArgument()
-						).visit( t )
-				)
+		n.worldParameters().forEach( w -> n.upperBound().forEach( t -> new DependencyVisitor(
+				this.availableTemplates,
+				this.projectableTemplates,
+				this.visitedTemplates,
+				w.toWorldArgument()
+		).visit( t )
+		)
 		);
 		return null;
 	}
@@ -570,13 +567,13 @@ public class DependencyVisitor implements ChoralVisitorInterface< Void > {
 	) {
 		List< WorldArgument > worlds =
 				Streams.concat(
-								compilationUnits.stream().map( CompilationUnit::interfaces ).flatMap(
-										List::stream ),
-								compilationUnits.stream().map( CompilationUnit::classes ).flatMap(
-										List::stream ),
-								compilationUnits.stream().map( CompilationUnit::enums ).flatMap(
-										List::stream )
-						).filter( t -> t.name().identifier().equals( template ) )
+						compilationUnits.stream().map( CompilationUnit::interfaces ).flatMap(
+								List::stream ),
+						compilationUnits.stream().map( CompilationUnit::classes ).flatMap(
+								List::stream ),
+						compilationUnits.stream().map( CompilationUnit::enums ).flatMap(
+								List::stream )
+				).filter( t -> t.name().identifier().equals( template ) )
 						.flatMap( t -> t.worldParameters().stream().map(
 								FormalWorldParameter::toWorldArgument ) )
 						.collect( Collectors.toList() );

--- a/choral/src/main/java/choral/compiler/soloist/ImportProjector.java
+++ b/choral/src/main/java/choral/compiler/soloist/ImportProjector.java
@@ -35,7 +35,8 @@ public class ImportProjector implements ChoralVisitorInterface< Void > {
 	private List< ImportDeclaration > projectAllImports( List< ImportDeclaration > cImports ) {
 		List< ImportDeclaration > pImports = new ArrayList<>();
 		for( ImportDeclaration i : cImports ) {
-			if( i.typeAnnotation().isPresent() && i.typeAnnotation().get().worldParameters().size() > 1 ) {
+			if( i.typeAnnotation().isPresent()
+					&& i.typeAnnotation().get().worldParameters().size() > 1 ) {
 				for( World worldParameter : i.typeAnnotation().get().worldParameters() ) {
 					pImports.add(
 							new ImportDeclaration( i.name() + "_" + worldParameter.identifier(),
@@ -346,12 +347,11 @@ public class ImportProjector implements ChoralVisitorInterface< Void > {
 
 	@Override
 	public Void visit( VariableDeclaration n ) {
-        if ( n.type().isPresent() ) {
-          		visit( n.type().get() );
-        }
-        else {
-            visit( n.typeAnnotation().get().reify() );
-        }
+		if( n.type().isPresent() ) {
+			visit( n.type().get() );
+		} else {
+			visit( n.typeAnnotation().get().reify() );
+		}
 		n.annotations().forEach( this::visit );
 		n.initializer().ifPresent( this::visit );
 		return null;
@@ -398,12 +398,11 @@ public class ImportProjector implements ChoralVisitorInterface< Void > {
 	private void addImport( String name ) {
 		usedImports.addAll(
 				imports.stream()
-						.filter( i ->
-								i.name().endsWith( "*" )
-										|| ( i.name().contains( "." )
+						.filter( i -> i.name().endsWith( "*" )
+								|| ( i.name().contains( "." )
 										&& i.name().substring(
-										i.name().lastIndexOf( "." ) + 1 ).equals( name ) )
-										|| i.name().equals( name )
+												i.name().lastIndexOf( "." ) + 1 ).equals( name ) )
+								|| i.name().equals( name )
 						).collect( Collectors.toSet() )
 		);
 		imports.removeAll( usedImports );

--- a/choral/src/main/java/choral/compiler/soloist/ImportProjector.java
+++ b/choral/src/main/java/choral/compiler/soloist/ImportProjector.java
@@ -346,7 +346,12 @@ public class ImportProjector implements ChoralVisitorInterface< Void > {
 
 	@Override
 	public Void visit( VariableDeclaration n ) {
-		visit( n.type() );
+        if ( n.type().isPresent() ) {
+          		visit( n.type().get() );
+        }
+        else {
+            visit( n.typeAnnotation().get().reify() );
+        }
 		n.annotations().forEach( this::visit );
 		n.initializer().ifPresent( this::visit );
 		return null;

--- a/choral/src/main/java/choral/compiler/soloist/SoloistProjector.java
+++ b/choral/src/main/java/choral/compiler/soloist/SoloistProjector.java
@@ -141,7 +141,7 @@ public class SoloistProjector extends ChoralVisitor {
 		PrettyPrinterVisitor printer = new PrettyPrinterVisitor();
 		for( T method : methods ) {
 			String parameterTypes = method.signature().parameters().stream()
-					.map( parameter -> printer.visit( parameter.type() ) )
+					.map( parameter -> printer.visit( parameter.type().get() ) )
 					.collect( Collectors.joining( ",", "(", ")" ) );
 			String signature = method.signature().name().identifier() + parameterTypes;
 			methodsBySignature.computeIfAbsent( signature, ignored -> new ArrayList<>() )

--- a/choral/src/main/java/choral/compiler/soloist/StatementsProjector.java
+++ b/choral/src/main/java/choral/compiler/soloist/StatementsProjector.java
@@ -96,12 +96,12 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 		return new TryCatchStatement(
 				visit( n.body() ),
 				n.catches().stream()
-						.filter( p -> p.left().type().worldArguments().contains( this.world ) )
+						.filter( p -> p.left().type().get().worldArguments().contains( this.world ) )
 						.map( p -> new Pair<>(
 								new VariableDeclaration(
 										p.left().name(),
 										TypesProjector.visit(
-												this.world(), p.left().type()
+												this.world(), p.left().type().get()
 										).get( 0 ),
 										p.left().annotations(),
 										null,
@@ -243,7 +243,7 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 			}
 		}
 
-		TypeExpression t = n.variables().get( 0 ).type();
+		TypeExpression t = n.variables().get( 0 ).inferredTypeExpression();
 		TypeExpression tp = TypesProjector.visit( this.world(), t ).get( 0 );
 		if( t.worldArguments().contains( this.world() ) ) {
 			return new VariableDeclarationStatement(

--- a/choral/src/main/java/choral/compiler/soloist/StatementsProjector.java
+++ b/choral/src/main/java/choral/compiler/soloist/StatementsProjector.java
@@ -96,7 +96,8 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 		return new TryCatchStatement(
 				visit( n.body() ),
 				n.catches().stream()
-						.filter( p -> p.left().type().get().worldArguments().contains( this.world ) )
+						.filter( p -> p.left().type().get().worldArguments()
+								.contains( this.world ) )
 						.map( p -> new Pair<>(
 								new VariableDeclaration(
 										p.left().name(),
@@ -108,8 +109,7 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 										p.left().modifiers()
 								),
 								visit( p.right() ) ) ) // add exceptions to gamma here
-						.collect( Collectors.toList() )
-				,
+						.collect( Collectors.toList() ),
 				visit( n.continuation() )
 		).copyPosition( n );
 		// TODO: do we check that we do not project an empty try clause without catches?
@@ -143,8 +143,10 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 		return (GroundClass) type;
 	}
 
-	private ScopedExpression getTypeSelectionGuard( Expression scope,
-			MethodCallExpression method ) {
+	private ScopedExpression getTypeSelectionGuard(
+			Expression scope,
+			MethodCallExpression method
+	) {
 		Optional< ? extends Member.GroundMethod > ann = method.methodAnnotation();
 
 		if( !ann.isPresent() ) {
@@ -173,7 +175,8 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 	}
 
 	private Optional< Pair< ScopedExpression, GroundClass > > isTypeSelectionMethodAtWorld(
-			Expression e ) {
+			Expression e
+	) {
 		// A type-driven selection is a `ScopedExpression`, where the scope is an expression that
 		// evaluates to a channel, and the nested expression is a `MethodCallExpression` that
 		// invokes a channel's type selection method.
@@ -204,8 +207,10 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 		return Optional.empty();
 	}
 
-	private static SwitchStatement selectionSwitchStatement( Expression guard,
-			SwitchArgument< ? > argument, Statement statement ) {
+	private static SwitchStatement selectionSwitchStatement(
+			Expression guard,
+			SwitchArgument< ? > argument, Statement statement
+	) {
 		Map< SwitchArgument< ? >, Statement > cases = new HashMap<>();
 		cases.put( argument, statement );
 		// NOTE: When generating code, `JavaCompiler` will replace the body of a
@@ -252,8 +257,8 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 									v.name(),
 									tp,
 									v.annotations(),
-									v.initializer().isEmpty() ? null
-											: (AssignExpression) ExpressionProjector.visit(
+									v.initializer().isEmpty() ? null :
+											(AssignExpression) ExpressionProjector.visit(
 													this.world(), v.initializer().get() ),
 									v.modifiers() ) )
 							.collect( Collectors.toList() ),
@@ -278,9 +283,10 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 			MethodCallExpression methodCall = ( (MethodCallExpression) e );
 			return methodCall.isSelect()
 					&& ( (GroundDataType) methodCall.methodAnnotation().get().returnType() )
-					.worldArguments().stream().map(
-							w -> new WorldArgument( new Name( w.identifier() ) ) ).collect(
-							Collectors.toList() ).contains( this.world() );
+							.worldArguments().stream().map(
+									w -> new WorldArgument( new Name( w.identifier() ) ) )
+							.collect( Collectors.toList() )
+							.contains( this.world() );
 		}
 		return false;
 	}
@@ -350,12 +356,12 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 		} else {
 			List< Statement > cases = List.of( visit( n.ifBranch() ), visit( n.elseBranch() ) );
 			return new ExpressionStatement(
-				ExpressionProjector.visit( this.world(), n.condition() ),
-				Continuation.continuationAfter(
-					StatementsMerger.merge( cases ),
-					visit( n.continuation() ).copyPosition( n ))
+					ExpressionProjector.visit( this.world(), n.condition() ),
+					Continuation.continuationAfter(
+							StatementsMerger.merge( cases ),
+							visit( n.continuation() ).copyPosition( n ) )
 			);
-			
+
 		}
 	}
 
@@ -364,10 +370,9 @@ public class StatementsProjector extends AbstractSoloistProjector< Statement > {
 		if( ExpressionProjector.atWorld( n.guard(), this.world() ) ) {
 			return new SwitchStatement(
 					ExpressionProjector.visit( this.world, n.guard() ),
-					n.cases().entrySet().stream().map( e ->
-							new Pair<>( e.getKey(),
-									visit( e.getValue() ) )
-					).collect( Streams.toLinkedHashMap( Pair::left, Pair::right ) ),
+					n.cases().entrySet().stream()
+							.map( e -> new Pair<>( e.getKey(), visit( e.getValue() ) ) )
+							.collect( Streams.toLinkedHashMap( Pair::left, Pair::right ) ),
 					visit( n.continuation() )
 			).copyPosition( n );
 		} else {

--- a/choral/src/main/java/choral/compiler/soloist/TypesProjector.java
+++ b/choral/src/main/java/choral/compiler/soloist/TypesProjector.java
@@ -68,26 +68,25 @@ public class TypesProjector extends AbstractSoloistProjector< List< ? extends No
 			if( dataType.isHigherType() ) {
 				HigherDataType higherDataType = (HigherDataType) dataType;
 				return higherDataType.worldParameters().stream()
-						.map( w ->
-								{
-									TypeExpression e = new TypeExpression(
-											new Name( Utils.getProjectionName(
-													n.name().identifier(),
-													new WorldArgument( new Name( w.identifier() ) ),
-													higherDataType.worldParameters().stream()
-															.map( wp -> new WorldArgument(
-																	new Name( wp.identifier() ) ) )
-															.collect( Collectors.toList() )
-											) ),
-											Collections.singletonList( this.world ),
-											n.typeArguments().stream()
-													.map( this::visit )
-													.flatMap( List::stream )
+						.map( w -> {
+							TypeExpression e = new TypeExpression(
+									new Name( Utils.getProjectionName(
+											n.name().identifier(),
+											new WorldArgument( new Name( w.identifier() ) ),
+											higherDataType.worldParameters().stream()
+													.map( wp -> new WorldArgument(
+															new Name( wp.identifier() ) ) )
 													.collect( Collectors.toList() )
-									).< TypeExpression >copyPosition( n );
-									e.setTypeAnnotation( higherDataType );
-									return e;
-								}
+									) ),
+									Collections.singletonList( this.world ),
+									n.typeArguments().stream()
+											.map( this::visit )
+											.flatMap( List::stream )
+											.collect( Collectors.toList() )
+							).< TypeExpression >copyPosition( n );
+							e.setTypeAnnotation( higherDataType );
+							return e;
+						}
 						)
 						.collect( Collectors.toList() );
 			} else {

--- a/choral/src/main/java/choral/compiler/soloist/TypesProjector.java
+++ b/choral/src/main/java/choral/compiler/soloist/TypesProjector.java
@@ -140,11 +140,12 @@ public class TypesProjector extends AbstractSoloistProjector< List< ? extends No
 
 	@Override
 	public List< VariableDeclaration > visit( VariableDeclaration n ) {
-		if( n.type().worldArguments().contains( this.world() ) ) {
+		TypeExpression type = n.inferredTypeExpression();
+		if( type.worldArguments().contains( this.world() ) ) {
 			return Collections.singletonList(
 					new VariableDeclaration(
 							n.name(),
-							visit( world(), n.type() ).get( 0 ),
+							visit( world(), type ).get( 0 ),
 							n.annotations(),
 							null,
 							n.modifiers(),

--- a/choral/src/main/java/choral/types/GroundClassOrInterface.java
+++ b/choral/src/main/java/choral/types/GroundClassOrInterface.java
@@ -21,6 +21,9 @@
 
 package choral.types;
 
+import choral.ast.Name;
+import choral.ast.type.TypeExpression;
+
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -41,6 +44,21 @@ public interface GroundClassOrInterface extends ClassOrInterface, GroundReferenc
 	}
 
 	List< ? extends HigherReferenceType > typeArguments();
+
+	@Override
+	default HigherReferenceType unapplyWorlds() {
+		return typeConstructor().partiallyApplyTo( typeArguments() );
+	}
+
+	@Override
+	default TypeExpression reify() {
+		TypeExpression expression = new TypeExpression(
+				new Name( typeConstructor().identifier() ),
+				reifyWorldArguments(),
+				typeArguments().stream().map( HigherReferenceType::reify ).toList() );
+		expression.setTypeAnnotation( this );
+		return expression;
+	}
 
 	GroundClassOrInterface applySubstitution( Substitution substitution );
 

--- a/choral/src/main/java/choral/types/GroundDataType.java
+++ b/choral/src/main/java/choral/types/GroundDataType.java
@@ -21,6 +21,10 @@
 
 package choral.types;
 
+import choral.ast.Name;
+import choral.ast.type.TypeExpression;
+import choral.ast.type.WorldArgument;
+
 import java.util.List;
 
 /**
@@ -48,6 +52,21 @@ public interface GroundDataType extends DataType, GroundDataTypeOrVoid {
 	HigherDataType typeConstructor();
 
 	List< ? extends World > worldArguments();
+
+	default List< WorldArgument > reifyWorldArguments() {
+		return worldArguments().stream()
+				.map( world -> {
+					WorldArgument argument = new WorldArgument( new Name( world.identifier() ), null );
+					argument.setTypeAnnotation( world );
+					return argument;
+				} )
+				.toList();
+	}
+
+	/**
+	 * Converts this (semantic) type into a (syntactic) type expression.
+	 */
+	TypeExpression reify();
 
 	boolean isInstantiationChecked();
 

--- a/choral/src/main/java/choral/types/GroundDataType.java
+++ b/choral/src/main/java/choral/types/GroundDataType.java
@@ -56,7 +56,8 @@ public interface GroundDataType extends DataType, GroundDataTypeOrVoid {
 	default List< WorldArgument > reifyWorldArguments() {
 		return worldArguments().stream()
 				.map( world -> {
-					WorldArgument argument = new WorldArgument( new Name( world.identifier() ), null );
+					WorldArgument argument =
+							new WorldArgument( new Name( world.identifier() ), null );
 					argument.setTypeAnnotation( world );
 					return argument;
 				} )
@@ -82,7 +83,7 @@ public interface GroundDataType extends DataType, GroundDataTypeOrVoid {
 
 	default boolean isAssignableTo_relaxed( GroundDataTypeOrVoid type ) {
 		return !type.isVoid() && ( type instanceof GroundDataType ) && isSubtypeOf_relaxed(
-			(GroundDataType) type );
+				(GroundDataType) type );
 	}
 
 	boolean isEquivalentToErasureOf( GroundDataType type );

--- a/choral/src/main/java/choral/types/GroundPrimitiveDataType.java
+++ b/choral/src/main/java/choral/types/GroundPrimitiveDataType.java
@@ -21,6 +21,11 @@
 
 package choral.types;
 
+import choral.ast.Name;
+import choral.ast.type.TypeExpression;
+
+import java.util.List;
+
 /** @see choral.types.GroundDataType */
 public interface GroundPrimitiveDataType extends GroundDataType, PrimitiveDataType {
 
@@ -29,6 +34,16 @@ public interface GroundPrimitiveDataType extends GroundDataType, PrimitiveDataTy
 
 	@Override
 	GroundPrimitiveDataType applySubstitution( Substitution substitution );
+
+	@Override
+	default TypeExpression reify() {
+		TypeExpression expression = new TypeExpression(
+				new Name( primitiveTypeTag().toString() ),
+				reifyWorldArguments(),
+				List.of() );
+		expression.setTypeAnnotation( this );
+		return expression;
+	}
 
 	@Override
 	default GroundClass boxedType() {

--- a/choral/src/main/java/choral/types/GroundPrimitiveDataType.java
+++ b/choral/src/main/java/choral/types/GroundPrimitiveDataType.java
@@ -56,7 +56,7 @@ public interface GroundPrimitiveDataType extends GroundDataType, PrimitiveDataTy
 			GroundDataType t = (GroundDataType) type;
 			return this.worldArguments().equals( t.worldArguments() )
 					&& ( this.primitiveTypeTag().isAssignableTo( t.primitiveTypeTag() )
-					|| this.boxedType().isEquivalentTo( t ) );
+							|| this.boxedType().isEquivalentTo( t ) );
 		} else {
 			return false;
 		}
@@ -66,7 +66,7 @@ public interface GroundPrimitiveDataType extends GroundDataType, PrimitiveDataTy
 		if( type instanceof GroundDataType ) {
 			GroundDataType t = (GroundDataType) type;
 			return this.primitiveTypeTag().isAssignableTo( t.primitiveTypeTag() )
-					|| this.boxedType().isEquivalentTo_relaxed( t ) ;
+					|| this.boxedType().isEquivalentTo_relaxed( t );
 		} else {
 			return false;
 		}

--- a/choral/src/main/java/choral/types/GroundReferenceType.java
+++ b/choral/src/main/java/choral/types/GroundReferenceType.java
@@ -30,6 +30,9 @@ public interface GroundReferenceType extends GroundDataType {
 	@Override
 	HigherReferenceType typeConstructor();
 
+	/** Converts this ground type back into a higher type by unapplying its world args. */
+	HigherReferenceType unapplyWorlds();
+
 	@Override
 	GroundReferenceType applySubstitution( Substitution substitution );
 

--- a/choral/src/main/java/choral/types/GroundTypeParameter.java
+++ b/choral/src/main/java/choral/types/GroundTypeParameter.java
@@ -21,6 +21,10 @@
 
 package choral.types;
 
+import choral.ast.Name;
+import choral.ast.type.TypeExpression;
+
+import java.util.List;
 import java.util.stream.Stream;
 
 /** @see choral.types.GroundDataType */
@@ -28,6 +32,21 @@ public interface GroundTypeParameter extends GroundReferenceType, TypeParameter 
 
 	@Override
 	HigherTypeParameter typeConstructor();
+
+	@Override
+	default HigherTypeParameter unapplyWorlds() {
+		return typeConstructor();
+	}
+
+	@Override
+	default TypeExpression reify() {
+		TypeExpression expression = new TypeExpression(
+				new Name( typeConstructor().identifier() ),
+				reifyWorldArguments(),
+				List.of() );
+		expression.setTypeAnnotation( this );
+		return expression;
+	}
 
 	boolean isBoundFinalised();
 

--- a/choral/src/main/java/choral/types/HigherClassOrInterface.java
+++ b/choral/src/main/java/choral/types/HigherClassOrInterface.java
@@ -21,7 +21,9 @@
 
 package choral.types;
 
+import choral.ast.Name;
 import choral.ast.Node;
+import choral.ast.type.TypeExpression;
 import choral.exceptions.StaticVerificationException;
 import choral.types.kinds.Kind;
 import choral.utils.Formatting;
@@ -207,6 +209,14 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 
 
 	@Override
+	public TypeExpression reify() {
+		TypeExpression expression = new TypeExpression(
+				new Name( identifier() ), Collections.emptyList(), Collections.emptyList() );
+		expression.setTypeAnnotation( this );
+		return expression;
+	}
+
+	@Override
 	public HigherReferenceType partiallyApplyTo( List< ? extends HigherReferenceType > typeArgs ) {
 		if( typeArgs.isEmpty() ) {
 			return this;
@@ -225,6 +235,16 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 		}
 
 		private final List< ? extends HigherReferenceType > typeArgs;
+
+		@Override
+		public TypeExpression reify() {
+			TypeExpression expression = new TypeExpression(
+					new Name( identifier() ),
+					Collections.emptyList(),
+					typeArgs.stream().map( HigherReferenceType::reify ).toList() );
+			expression.setTypeAnnotation( this );
+			return expression;
+		}
 
 		@Override
 		public String toString() {

--- a/choral/src/main/java/choral/types/HigherClassOrInterface.java
+++ b/choral/src/main/java/choral/types/HigherClassOrInterface.java
@@ -248,15 +248,8 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 
 		@Override
 		public String toString() {
-			return //this.worldParameters.stream().map( World::toString ).collect(
-					//Formatting.joining( ",", "@(", ")->(", "" ) )
-					identifier( true )
-							//+ this.worldParameters.stream().map( World::toString ).collect(
-							//Formatting.joining( ",", "@(", ")", "" ) )
-							+ this.typeArgs.stream().map( HigherReferenceType::toString ).collect(
-							Formatting.joining( ",", "<", ">", "" ) )
-					//+ ")"
-					;
+			return identifier( true ) + this.typeArgs.stream().map( HigherReferenceType::toString )
+					.collect( Formatting.joining( ",", "<", ">", "" ) );
 		}
 
 		@Override
@@ -270,7 +263,7 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 				Lambda other = (Lambda) obj;
 				return this.isSameKind( other ) && this.applyTo(
 						this.worldParameters ).isEquivalentTo(
-						other.applyTo( this.worldParameters ) );
+								other.applyTo( this.worldParameters ) );
 			}
 			return false;
 		}
@@ -307,7 +300,8 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 		super.checkApplicationArguments( worldArgs );
 		if( typeArgs.size() != typeParameters.size() ) {
 			throw new StaticVerificationException(
-					"illegal type instantiation: expected " + typeParameters.size() + " type arguments but found " + typeArgs.size() );
+					"illegal type instantiation: expected " + typeParameters.size()
+							+ " type arguments but found " + typeArgs.size() );
 		}
 	}
 
@@ -333,11 +327,11 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 		}
 
 		public final String toString() {
-			return typeConstructor().toString() +
-					worldArguments().stream().map( World::toString ).collect(
-							Formatting.joining( ",", "@(", ")", "" ) ) +
-					typeArguments().stream().map( HigherReferenceType::toString ).collect(
-							Formatting.joining( ",", "<", ">", "" ) );
+			return typeConstructor().toString() + worldArguments().stream().map( World::toString )
+					.collect(
+							Formatting.joining( ",", "@(", ")", "" ) ) + typeArguments().stream()
+									.map( HigherReferenceType::toString ).collect(
+											Formatting.joining( ",", "<", ">", "" ) );
 		}
 
 		@Override
@@ -355,20 +349,20 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 		public void finaliseInheritance() {
 			if( !isInheritanceFinalised() ) {
 				allExtendedInterfaces = Stream.concat( extendedInterfaces(),
-								extendedClassesOrInterfaces().flatMap(
-										GroundClassOrInterface::allExtendedInterfaces ) )
+						extendedClassesOrInterfaces().flatMap(
+								GroundClassOrInterface::allExtendedInterfaces ) )
 						.collect( Collectors.toList() );
 				extendedClassesOrInterfaces().flatMap(
-								GroundClassOrInterface::allExtendedInterfaces )
-						.forEach( x -> extendedInterfaces().filter( y ->
-								x.typeConstructor() == y.typeConstructor() &&
+						GroundClassOrInterface::allExtendedInterfaces )
+						.forEach( x -> extendedInterfaces().filter(
+								y -> x.typeConstructor() == y.typeConstructor() &&
 										x.worldArguments().equals( y.worldArguments() ) &&
 										!x.typeArguments().equals( y.typeArguments() )
 						).findAny().ifPresent( y -> {
-									throw new StaticVerificationException(
-											"illegal inheritance, cannot implement both '"
-													+ y + "' and " + x + "'" );
-								}
+							throw new StaticVerificationException(
+									"illegal inheritance, cannot implement both '"
+											+ y + "' and " + x + "'" );
+						}
 						) );
 				inheritanceFinalised = true;
 			}
@@ -383,7 +377,8 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 			if( type.worldArguments().size() != worldArguments().size() ||
 					!type.worldArguments().containsAll( worldParameters ) ) {
 				throw new StaticVerificationException(
-						"illegal inheritance, '" + type + "' and '" + this + "' must have the same roles" );
+						"illegal inheritance, '" + type + "' and '" + this
+								+ "' must have the same roles" );
 			}
 			if( extendedInterfaces().anyMatch( x -> x.isEquivalentTo( type ) ) ) {
 				throw new StaticVerificationException(
@@ -426,12 +421,13 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 				return true;
 			} else if( type instanceof Proxy ) {
 				Proxy other = (Proxy) type;
-				if (other.definition() != this)
+				if( other.definition() != this )
 					return false;
-				if (typeArguments().size() != other.typeArguments().size())
+				if( typeArguments().size() != other.typeArguments().size() )
 					return false;
-				for( int i = 0; i < typeArguments().size(); i++ ){
-					if ( !typeArguments().get(i).isEquivalentTo_relaxed( other.typeArguments().get(i) ) )
+				for( int i = 0; i < typeArguments().size(); i++ ) {
+					if( !typeArguments().get( i )
+							.isEquivalentTo_relaxed( other.typeArguments().get( i ) ) )
 						return false;
 				}
 				return true;
@@ -445,7 +441,7 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 			return ( !strict && isEquivalentTo( type ) )
 					|| extendedInterfaces().anyMatch( x -> x.isSubtypeOf( type, false ) )
 					|| ( type.isEquivalentTo(
-					universe().topReferenceType( worldArguments() ) ) );
+							universe().topReferenceType( worldArguments() ) ) );
 		}
 
 		@Override
@@ -453,7 +449,7 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 			return ( !strict && isEquivalentTo_relaxed( type ) )
 					|| extendedInterfaces().anyMatch( x -> x.isSubtypeOf_relaxed( type, false ) )
 					|| ( type.isEquivalentTo_relaxed(
-					universe().topReferenceType( worldArguments() ) ) );
+							universe().topReferenceType( worldArguments() ) ) );
 		}
 
 		private boolean interfaceFinalised = false;
@@ -482,7 +478,8 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 		private void inheritFields() {
 			extendedClassesOrInterfaces().flatMap( GroundReferenceType::fields )
 					.filter( x -> x.isAccessibleFrom( this ) &&
-							declaredFields().noneMatch( y -> x.identifier().equals( y.identifier() ) ) )
+							declaredFields()
+									.noneMatch( y -> x.identifier().equals( y.identifier() ) ) )
 					.forEach( inheritedFields::add );
 		}
 
@@ -499,11 +496,10 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 				// === CLASS INHERITANCE (JLS 8.4.8) ===
 
 				// Phase 1a: Inherit concrete methods from direct superclass
-				gc.extendedClass().ifPresent( superclass ->
-						superclass.methods()
-								.filter( m -> !m.isAbstract() && m.isAccessibleFrom( this ) )
-								.forEach( m -> collectCandidate(
-										m, candidates, implementedByDeclared ) )
+				gc.extendedClass().ifPresent( superclass -> superclass.methods()
+						.filter( m -> !m.isAbstract() && m.isAccessibleFrom( this ) )
+						.forEach( m -> collectCandidate(
+								m, candidates, implementedByDeclared ) )
 				);
 
 				List< Member.HigherMethod > concreteSuperclassMethods =
@@ -511,12 +507,11 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 
 				// (JLS 8.4.8 (d)) An abstract supertype method is not inherited if a
 				// concrete superclass method already has a subsignature.
-				gc.extendedClass().ifPresent( superclass ->
-						superclass.methods()
-								.filter( m -> m.isAbstract() && m.isAccessibleFrom( this ) )
-								.forEach( m -> collectCandidateIfNotSatisfied(
-										m, candidates, concreteSuperclassMethods,
-										implementedByDeclared ) )
+				gc.extendedClass().ifPresent( superclass -> superclass.methods()
+						.filter( m -> m.isAbstract() && m.isAccessibleFrom( this ) )
+						.forEach( m -> collectCandidateIfNotSatisfied(
+								m, candidates, concreteSuperclassMethods,
+								implementedByDeclared ) )
 				);
 
 				// (JLS 9.4.1.1) Static interface methods are not inherited.
@@ -826,16 +821,15 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 		 * error for a concrete subclass.
 		 */
 		private void checkInaccessibleAbstractObligations( GroundClass gc ) {
-			gc.extendedClass().ifPresent( superclass ->
-					superclass.methods()
-							.filter( m -> m.isAbstract() && !m.isAccessibleFrom( this ) )
-							.forEach( m -> {
-								throw new StaticVerificationException(
-										"Implementation is not abstract and does not"
-												+ " override abstract method '"
-												+ m + "' in '"
-												+ m.declarationContext() + "'" );
-							} )
+			gc.extendedClass().ifPresent( superclass -> superclass.methods()
+					.filter( m -> m.isAbstract() && !m.isAccessibleFrom( this ) )
+					.forEach( m -> {
+						throw new StaticVerificationException(
+								"Implementation is not abstract and does not"
+										+ " override abstract method '"
+										+ m + "' in '"
+										+ m.declarationContext() + "'" );
+					} )
 			);
 		}
 
@@ -867,7 +861,9 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 			} );
 		}
 
-		private void checkOverrideRequirementsOrThrow(Member.HigherMethod child, Member.HigherMethod parent) {
+		private void checkOverrideRequirementsOrThrow(
+				Member.HigherMethod child, Member.HigherMethod parent
+		) {
 			// (8.4.3.3) Ensure we're not overriding a final method
 			if( parent.isFinal() ) {
 				throw new StaticVerificationException( "method '" + child
@@ -887,7 +883,7 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 						+ parent + "' in '" + parent.declarationContext() + "'" );
 			}
 			// (8.4.8.3) Ensure method return types are covariant
-			if( !child.isReturnTypeSubstitutableFor(parent) ) {
+			if( !child.isReturnTypeSubstitutableFor( parent ) ) {
 				throw new StaticVerificationException( "method '" + child
 						+ "' in '" + this + "' clashes with method '"
 						+ parent + "' in '" + parent.declarationContext()
@@ -939,7 +935,8 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 			if( declaredFields().anyMatch( x -> x.identifier().equals( field.identifier() ) ) ) {
 				throw new StaticVerificationException(
 						"duplicate variable '" + field.identifier() + "' in "
-								+ typeConstructor().variety().labelSingular + " '" + typeConstructor() );
+								+ typeConstructor().variety().labelSingular + " '"
+								+ typeConstructor() );
 			}
 			declaredFields.add( field );
 		}
@@ -978,11 +975,11 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 		}
 
 		public final String toString() {
-			return typeConstructor().toString() +
-					worldArguments().stream().map( World::toString ).collect(
-							Formatting.joining( ",", "@(", ")", "" ) ) +
-					typeArguments().stream().map( HigherReferenceType::toString ).collect(
-							Formatting.joining( ",", "<", ">", "" ) );
+			return typeConstructor().toString() + worldArguments().stream().map( World::toString )
+					.collect(
+							Formatting.joining( ",", "@(", ")", "" ) ) + typeArguments().stream()
+									.map( HigherReferenceType::toString ).collect(
+											Formatting.joining( ",", "<", ">", "" ) );
 		}
 
 		public final List< ? extends HigherReferenceType > typeArguments() {
@@ -1047,16 +1044,17 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 				return type.isEquivalentTo_relaxed( this );
 			} else if( type instanceof Proxy ) {
 				Proxy other = (Proxy) type;
-				if (this.definition() != other.definition())
+				if( this.definition() != other.definition() )
 					return false;
-				if (typeArguments().size() != other.typeArguments().size()) 
+				if( typeArguments().size() != other.typeArguments().size() )
 					return false;
-				for( int i = 0; i < typeArguments().size(); i++ ){
-					if ( !typeArguments().get(i).isEquivalentTo_relaxed( other.typeArguments().get(i) ) )
+				for( int i = 0; i < typeArguments().size(); i++ ) {
+					if( !typeArguments().get( i )
+							.isEquivalentTo_relaxed( other.typeArguments().get( i ) ) )
 						return false;
 				}
 				return true;
-						
+
 			} else {
 				return false;
 			}
@@ -1067,7 +1065,7 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 			return ( !strict && isEquivalentTo( type ) )
 					|| extendedInterfaces().anyMatch( x -> x.isSubtypeOf( type, false ) )
 					|| ( type.isEquivalentTo(
-					universe().topReferenceType( worldArguments() ) ) );
+							universe().topReferenceType( worldArguments() ) ) );
 		}
 
 		@Override
@@ -1075,7 +1073,7 @@ public abstract class HigherClassOrInterface extends HigherReferenceType
 			return ( !strict && isEquivalentTo_relaxed( type ) )
 					|| extendedInterfaces().anyMatch( x -> x.isSubtypeOf_relaxed( type, false ) )
 					|| ( type.isEquivalentTo_relaxed(
-					universe().topReferenceType( worldArguments() ) ) );
+							universe().topReferenceType( worldArguments() ) ) );
 		}
 
 		@Override

--- a/choral/src/main/java/choral/types/HigherReferenceType.java
+++ b/choral/src/main/java/choral/types/HigherReferenceType.java
@@ -21,6 +21,8 @@
 
 package choral.types;
 
+import choral.ast.type.TypeExpression;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -36,6 +38,11 @@ public abstract class HigherReferenceType extends HigherDataType implements Refe
 	}
 
 //	public abstract HigherReferenceType.Definition innerType();
+
+	/**
+	 * Converts this (semantic) type into a (syntactic) type expression.
+	 */
+	public abstract TypeExpression reify();
 
 	public abstract GroundReferenceType applyTo( List< ? extends World > args );
 

--- a/choral/src/main/java/choral/types/HigherTypeParameter.java
+++ b/choral/src/main/java/choral/types/HigherTypeParameter.java
@@ -124,9 +124,7 @@ public final class HigherTypeParameter extends HigherReferenceType implements Ty
 				@Override
 				public World get( World placeHolder ) {
 					int i = worldParameters.indexOf( placeHolder );
-					return ( i < 0 )
-							? substitution.get( placeHolder )
-							: worldArgs.get( i );
+					return ( i < 0 ) ? substitution.get( placeHolder ) : worldArgs.get( i );
 				}
 
 				@Override
@@ -161,9 +159,8 @@ public final class HigherTypeParameter extends HigherReferenceType implements Ty
 		}
 
 		public String toString() {
-			return typeConstructor().toString() +
-					worldArguments().stream().map( World::toString ).collect(
-							Formatting.joining( ",", "@(", ")", "" ) );
+			return typeConstructor().toString() + worldArguments().stream().map( World::toString )
+					.collect( Formatting.joining( ",", "@(", ")", "" ) );
 		}
 
 		@Override
@@ -237,7 +234,8 @@ public final class HigherTypeParameter extends HigherReferenceType implements Ty
 			if( type.worldArguments().size() != worldArguments().size() ||
 					!type.worldArguments().containsAll( worldParameters ) ) {
 				throw new StaticVerificationException(
-						"illegal bound, '" + type + "' and '" + this + "' must have the same roles" );
+						"illegal bound, '" + type + "' and '" + this
+								+ "' must have the same roles" );
 			}
 			if( type instanceof GroundInterface ) {
 				if( upperClass == null ) {
@@ -379,9 +377,8 @@ public final class HigherTypeParameter extends HigherReferenceType implements Ty
 
 		@Override
 		public String toString() {
-			return typeConstructor().toString() +
-					worldArguments().stream().map( World::toString ).collect(
-							Formatting.joining( ",", "@(", ")", "" ) );
+			return typeConstructor().toString() + worldArguments().stream().map( World::toString )
+					.collect( Formatting.joining( ",", "@(", ")", "" ) );
 		}
 
 		@Override

--- a/choral/src/main/java/choral/types/HigherTypeParameter.java
+++ b/choral/src/main/java/choral/types/HigherTypeParameter.java
@@ -21,7 +21,9 @@
 
 package choral.types;
 
+import choral.ast.Name;
 import choral.ast.Node;
+import choral.ast.type.TypeExpression;
 import choral.exceptions.StaticVerificationException;
 import choral.utils.Formatting;
 
@@ -61,6 +63,14 @@ public final class HigherTypeParameter extends HigherReferenceType implements Ty
 	}
 
 	@Override
+	public TypeExpression reify() {
+		TypeExpression expression = new TypeExpression(
+				new Name( identifier ), List.of(), List.of() );
+		expression.setTypeAnnotation( this );
+		return expression;
+	}
+
+	@Override
 	public String toString() {
 		return identifier;
 	}
@@ -82,6 +92,13 @@ public final class HigherTypeParameter extends HigherReferenceType implements Ty
 					this.worldParameters.stream()
 							.map( x -> new World( universe(), x.identifier() ) ).collect(
 									Collectors.toList() ) ) {
+				@Override
+				public TypeExpression reify() {
+					TypeExpression expression = HigherTypeParameter.this.reify();
+					expression.setTypeAnnotation( this );
+					return expression;
+				}
+
 				@Override
 				public GroundReferenceType applyTo( List< ? extends World > args ) {
 					return HigherTypeParameter.this.applyTo( args );

--- a/choral/src/main/java/choral/types/Universe.java
+++ b/choral/src/main/java/choral/types/Universe.java
@@ -21,6 +21,7 @@
 
 package choral.types;
 
+import choral.ast.type.TypeExpression;
 import choral.exceptions.StaticVerificationException;
 import choral.types.kinds.Kind;
 import choral.utils.Formatting;
@@ -249,6 +250,11 @@ public class Universe {
 			super( Universe.this, worldParameters );
 		}
 
+		@Override
+		public TypeExpression reify() {
+			throw new UnsupportedOperationException( "The null type cannot be used in a type expression" );
+		}
+
 		public String toString() {
 			return this.worldParameters.stream().map( World::toString ).collect(
 					Formatting.joining( ",", "@(", ")->(", "" ) )
@@ -284,6 +290,12 @@ public class Universe {
 				return worldArguments;
 			}
 
+			@Override
+			public TypeExpression reify() {
+				throw new UnsupportedOperationException(
+						"The null type cannot be used in a type expression" );
+			}
+
 			public String toString() {
 				return "Null" +
 						worldArguments().stream().map( World::toString ).collect(
@@ -293,6 +305,11 @@ public class Universe {
 			@Override
 			public HigherNullType typeConstructor() {
 				return HigherNullType.this;
+			}
+
+			@Override
+			public HigherNullType unapplyWorlds() {
+				return typeConstructor();
 			}
 
 			@Override

--- a/choral/src/main/java/choral/types/Universe.java
+++ b/choral/src/main/java/choral/types/Universe.java
@@ -48,7 +48,7 @@ public class Universe {
 	}
 
 	private static final HashMap< String, SpecialTypeTag > specialClassesConversionMap =
-		new HashMap<>( 11 );
+			new HashMap<>( 11 );
 
 	public enum SpecialTypeTag {
 		OBJECT( "java.lang.Object", HigherClassOrInterface.Variety.CLASS ),
@@ -80,8 +80,8 @@ public class Universe {
 		}
 	}
 
-	private static final HashMap< String, PrimitiveTypeTag > primitiveTypesConversionMap = new HashMap<>(
-			8 );
+	private static final HashMap< String, PrimitiveTypeTag > primitiveTypesConversionMap =
+			new HashMap<>( 8 );
 	private static final Map< SpecialTypeTag, PrimitiveTypeTag > unboxingMap = new EnumMap<>(
 			SpecialTypeTag.class );
 
@@ -173,14 +173,15 @@ public class Universe {
 				specialClasses.put( key, type );
 			} else {
 				throw new StaticVerificationException(
-						"Invalid special type '" + type.identifier() + "', expected " + key.variety.labelSingular + " found " + type.variety() );
+						"Invalid special type '" + type.identifier() + "', expected "
+								+ key.variety.labelSingular + " found " + type.variety() );
 			}
 		}
 		return key;
 	}
 
-	public Optional<SpecialTypeTag> specialTypeTag(String qualifiedName) {
-		return Optional.ofNullable(specialClassesConversionMap.get(qualifiedName));
+	public Optional< SpecialTypeTag > specialTypeTag( String qualifiedName ) {
+		return Optional.ofNullable( specialClassesConversionMap.get( qualifiedName ) );
 	}
 
 	public HigherClassOrInterface specialType( SpecialTypeTag key ) {
@@ -252,7 +253,8 @@ public class Universe {
 
 		@Override
 		public TypeExpression reify() {
-			throw new UnsupportedOperationException( "The null type cannot be used in a type expression" );
+			throw new UnsupportedOperationException(
+					"The null type cannot be used in a type expression" );
 		}
 
 		public String toString() {
@@ -260,7 +262,7 @@ public class Universe {
 					Formatting.joining( ",", "@(", ")->(", "" ) )
 					+ "Null"
 					+ this.worldParameters.stream().map( World::toString ).collect(
-					Formatting.joining( ",", "@(", ")", "" ) )
+							Formatting.joining( ",", "@(", ")", "" ) )
 					+ ")";
 		}
 

--- a/choral/src/test/java/NormalizerTest.java
+++ b/choral/src/test/java/NormalizerTest.java
@@ -52,9 +52,10 @@ public class NormalizerTest {
 	}
 
 	private static List< VariableDeclaration > hoistsForMethod(
-			Normalizer.Result result, String methodName ) {
-		for( Map.Entry< Member.HigherCallable, List< VariableDeclaration > > entry :
-				result.hoistedDefinitions().entrySet() ) {
+			Normalizer.Result result, String methodName
+	) {
+		for( Map.Entry< Member.HigherCallable, List< VariableDeclaration > > entry : result
+				.hoistedDefinitions().entrySet() ) {
 			if( entry.getKey() instanceof Member.HigherMethod method
 					&& method.identifier().equals( methodName ) ) {
 				return entry.getValue();
@@ -64,9 +65,10 @@ public class NormalizerTest {
 	}
 
 	private static List< VariableDeclaration > hoistsForConstructor(
-			Normalizer.Result result, String className ) {
-		for( Map.Entry< Member.HigherCallable, List< VariableDeclaration > > entry :
-				result.hoistedDefinitions().entrySet() ) {
+			Normalizer.Result result, String className
+	) {
+		for( Map.Entry< Member.HigherCallable, List< VariableDeclaration > > entry : result
+				.hoistedDefinitions().entrySet() ) {
 			if( entry.getKey() instanceof Member.HigherConstructor constructor
 					&& constructor.declarationContext().typeConstructor().identifier()
 							.equals( className ) ) {
@@ -84,877 +86,830 @@ public class NormalizerTest {
 
 	@Test
 	public void emptyClass() throws IOException {
-		String src =
-			"""
-			package test;
-			class Empty@( A ) { }
-			""";
+		String src = """
+				package test;
+				class Empty@( A ) { }
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void sameWorldAssignment() throws IOException {
-		String src =
-			"""
-			package test;
-			class SameWorld@( A ) {
-				public void m() {
-					Integer@A x = 1@A;
-					Integer@A y = x + 1@A;
+		String src = """
+				package test;
+				class SameWorld@( A ) {
+					public void m() {
+						Integer@A x = 1@A;
+						Integer@A y = x + 1@A;
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void sameWorldMethodCall() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A ) {
-				public Integer@A m( Integer@A x ) { return x; }
-				public void run() {
-					Integer@A y = this.m( 1@A );
+		String src = """
+				package test;
+				class C@( A ) {
+					public Integer@A m( Integer@A x ) { return x; }
+					public void run() {
+						Integer@A y = this.m( 1@A );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void sameWorldIfReturn() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A ) {
-				public Integer@A m( Boolean@A b ) {
-					if( b ) { return 1@A; } else { return 2@A; }
+		String src = """
+				package test;
+				class C@( A ) {
+					public Integer@A m( Boolean@A b ) {
+						if( b ) { return 1@A; } else { return 2@A; }
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void sameWorldBlockAndNot() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A ) {
-				public Boolean@A m( Boolean@A b ) {
-					{ Boolean@A c = !b; return c; }
+		String src = """
+				package test;
+				class C@( A ) {
+					public Boolean@A m( Boolean@A b ) {
+						{ Boolean@A c = !b; return c; }
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void sameWorldEnclosed() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A ) {
-				public Integer@A m() {
-					Integer@A x = ( 1@A + 2@A );
-					return x;
+		String src = """
+				package test;
+				class C@( A ) {
+					public Integer@A m() {
+						Integer@A x = ( 1@A + 2@A );
+						return x;
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsCrossWorldMethodArg() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A take( Integer@A x ) { return x; }
-				public void run( Integer@B b ) {
-					this.take( b );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A take( Integer@A x ) { return x; }
+					public void run( Integer@B b ) {
+						this.take( b );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A take( Integer@A x ) { return x; }
-				public void run( Integer@B b ) {
-					Integer@A msg0 = b;
-					this.take( msg0 );
+				""";
+		String expected = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A take( Integer@A x ) { return x; }
+					public void run( Integer@B b ) {
+						Integer@A msg0 = b;
+						this.take( msg0 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsTwoCrossWorldArgsInOrder() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B, D ) {
-				public Integer@A take( Integer@A x, Integer@A y ) { return x; }
-				public void run( Integer@B b, Integer@D d ) {
-					this.take( b, d );
+		String src = """
+				package test;
+				class C@( A, B, D ) {
+					public Integer@A take( Integer@A x, Integer@A y ) { return x; }
+					public void run( Integer@B b, Integer@D d ) {
+						this.take( b, d );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B, D ) {
-				public Integer@A take( Integer@A x, Integer@A y ) { return x; }
-				public void run( Integer@B b, Integer@D d ) {
-					Integer@A msg0 = b;
-					Integer@A msg1 = d;
-					this.take( msg0, msg1 );
+				""";
+		String expected = """
+				package test;
+				class C@( A, B, D ) {
+					public Integer@A take( Integer@A x, Integer@A y ) { return x; }
+					public void run( Integer@B b, Integer@D d ) {
+						Integer@A msg0 = b;
+						Integer@A msg1 = d;
+						this.take( msg0, msg1 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void sameWorldArgsNotHoisted() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A take( Integer@A x ) { return x; }
-				public void run( Integer@A a ) {
-					this.take( a );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A take( Integer@A x ) { return x; }
+					public void run( Integer@A a ) {
+						this.take( a );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsCrossWorldBinaryRightOperand() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run( Integer@A a, Integer@B b ) {
-					Integer@A z = a + b;
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public void run( Integer@A a, Integer@B b ) {
+						Integer@A z = a + b;
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run( Integer@A a, Integer@B b ) {
-					Integer@A msg0 = b;
-					Integer@A z = a + msg0;
+				""";
+		String expected = """
+				package test;
+				class C@( A, B ) {
+					public void run( Integer@A a, Integer@B b ) {
+						Integer@A msg0 = b;
+						Integer@A z = a + msg0;
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsCrossWorldAssignRhs() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run( Integer@A a, Integer@B b ) {
-					a = b;
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public void run( Integer@A a, Integer@B b ) {
+						a = b;
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run( Integer@A a, Integer@B b ) {
-					Integer@A msg0 = b;
-					a = msg0;
-				}
-			}
-		""";
+				""";
+		String expected = """
+					package test;
+					class C@( A, B ) {
+						public void run( Integer@A a, Integer@B b ) {
+							Integer@A msg0 = b;
+							a = msg0;
+						}
+					}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsNestedAlternatingWorldMethodCallsInsideOut() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A takeA( Integer@A x ) { return x; }
-				public Integer@B makeB( Integer@B x ) { return x; }
-				public void run( Integer@A a ) {
-					this.takeA( this.makeB( a ) );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A takeA( Integer@A x ) { return x; }
+					public Integer@B makeB( Integer@B x ) { return x; }
+					public void run( Integer@A a ) {
+						this.takeA( this.makeB( a ) );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A takeA( Integer@A x ) { return x; }
-				public Integer@B makeB( Integer@B x ) { return x; }
-				public void run( Integer@A a ) {
-					Integer@B msg0 = a;
-					Integer@A msg1 = this.makeB( msg0 );
-					this.takeA( msg1 );
+				""";
+		String expected = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A takeA( Integer@A x ) { return x; }
+					public Integer@B makeB( Integer@B x ) { return x; }
+					public void run( Integer@A a ) {
+						Integer@B msg0 = a;
+						Integer@A msg1 = this.makeB( msg0 );
+						this.takeA( msg1 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsThreeLevelAlternatingWorldMethodCallsInsideOut() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A takeA( Integer@A x ) { return x; }
-				public Integer@B makeB( Integer@B x ) { return x; }
-				public void run( Integer@B b ) {
-					this.takeA( this.makeB( this.takeA( b ) ) );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A takeA( Integer@A x ) { return x; }
+					public Integer@B makeB( Integer@B x ) { return x; }
+					public void run( Integer@B b ) {
+						this.takeA( this.makeB( this.takeA( b ) ) );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A takeA( Integer@A x ) { return x; }
-				public Integer@B makeB( Integer@B x ) { return x; }
-				public void run( Integer@B b ) {
-					Integer@A msg0 = b;
-					Integer@B msg1 = this.takeA( msg0 );
-					Integer@A msg2 = this.makeB( msg1 );
-					this.takeA( msg2 );
+				""";
+		String expected = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A takeA( Integer@A x ) { return x; }
+					public Integer@B makeB( Integer@B x ) { return x; }
+					public void run( Integer@B b ) {
+						Integer@A msg0 = b;
+						Integer@B msg1 = this.takeA( msg0 );
+						Integer@A msg2 = this.makeB( msg1 );
+						this.takeA( msg2 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsNotExpressionAsWhole() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void take( Boolean@A x ) {}
-				public void run( Boolean@B b ) {
-					this.take( !b );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public void take( Boolean@A x ) {}
+					public void run( Boolean@B b ) {
+						this.take( !b );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void take( Boolean@A x ) {}
-				public void run( Boolean@B b ) {
-					Boolean@A msg0 = !b;
-					this.take( msg0 );
+				""";
+		String expected = """
+				package test;
+				class C@( A, B ) {
+					public void take( Boolean@A x ) {}
+					public void run( Boolean@B b ) {
+						Boolean@A msg0 = !b;
+						this.take( msg0 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsEnclosedExpressionAsWhole() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void take( Integer@A x ) {}
-				public void run( Integer@B b ) {
-					this.take( ( b ) );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public void take( Integer@A x ) {}
+					public void run( Integer@B b ) {
+						this.take( ( b ) );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void take( Integer@A x ) {}
-				public void run( Integer@B b ) {
-					Integer@A msg0 = ( b );
-					this.take( msg0 );
-				}
-			}
-		""";
+				""";
+		String expected = """
+					package test;
+					class C@( A, B ) {
+						public void take( Integer@A x ) {}
+						public void run( Integer@B b ) {
+							Integer@A msg0 = ( b );
+							this.take( msg0 );
+						}
+					}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsThisFieldAccessAsWhole() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A x;
-				public void take( Integer@B x ) {}
-				public void run() {
-					this.take( this.x );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A x;
+					public void take( Integer@B x ) {}
+					public void run() {
+						this.take( this.x );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public Integer@A x;
-				public void take( Integer@B x ) {}
-				public void run() {
-					Integer@B msg0 = this.x;
-					this.take( msg0 );
+				""";
+		String expected = """
+				package test;
+				class C@( A, B ) {
+					public Integer@A x;
+					public void take( Integer@B x ) {}
+					public void run() {
+						Integer@B msg0 = this.x;
+						this.take( msg0 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsSuperFieldAccessAsWhole() throws IOException {
-		String src =
-			"""
-			package test;
-			class Base@( D, E ) {
-				public Integer@D x;
-			}
-			class C@( A, B ) extends Base@( A, B ) {
-				public void take( Integer@B x ) {}
-				public void run() {
-					this.take( super.x );
+		String src = """
+				package test;
+				class Base@( D, E ) {
+					public Integer@D x;
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Base@( D, E ) {
-				public Integer@D x;
-			}
-			class C@( A, B ) extends Base@( A, B ) {
-				public void take( Integer@B x ) {}
-				public void run() {
-					Integer@B msg0 = super.x;
-					this.take( msg0 );
+				class C@( A, B ) extends Base@( A, B ) {
+					public void take( Integer@B x ) {}
+					public void run() {
+						this.take( super.x );
+					}
 				}
-			}
-			""";
+				""";
+		String expected = """
+				package test;
+				class Base@( D, E ) {
+					public Integer@D x;
+				}
+				class C@( A, B ) extends Base@( A, B ) {
+					public void take( Integer@B x ) {}
+					public void run() {
+						Integer@B msg0 = super.x;
+						this.take( msg0 );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsScopedFieldAccess() throws IOException {
-		String src =
-			"""
-			package test;
-			class Pair@D {
-				public Integer@D x;
-				public Pair( Integer@D x ) { this.x = x; }
-			}
-			class C@( A, B ) {
-				public void take( Integer@A x ) {}
-				public void run( Pair@B p ) {
-					this.take( p.x );
+		String src = """
+				package test;
+				class Pair@D {
+					public Integer@D x;
+					public Pair( Integer@D x ) { this.x = x; }
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Pair@D {
-				public Integer@D x;
-				public Pair( Integer@D x ) { this.x = x; }
-			}
-			class C@( A, B ) {
-				public void take( Integer@A x ) {}
-				public void run( Pair@B p ) {
-					Integer@A msg0 = p.x;
-					this.take( msg0 );
+				class C@( A, B ) {
+					public void take( Integer@A x ) {}
+					public void run( Pair@B p ) {
+						this.take( p.x );
+					}
 				}
-			}
-		""";
+				""";
+		String expected = """
+				package test;
+				class Pair@D {
+					public Integer@D x;
+					public Pair( Integer@D x ) { this.x = x; }
+				}
+				class C@( A, B ) {
+					public void take( Integer@A x ) {}
+					public void run( Pair@B p ) {
+						Integer@A msg0 = p.x;
+						this.take( msg0 );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void sameWorldDeepScopedFieldAccessNotHoisted() throws IOException {
-		String src =
-			"""
-			package test;
-			class Leaf@D {
-				public Integer@D baz;
-				public Leaf( Integer@D baz ) { this.baz = baz; }
-			}
-			class Middle@D {
-				public Leaf@D bar;
-				public Middle( Leaf@D bar ) { this.bar = bar; }
-			}
-			class Foo@D {
-				public Middle@D bar;
-				public Foo( Middle@D bar ) { this.bar = bar; }
-			}
-			class C@( A ) {
-				public void take( Integer@A x ) {}
-				public void run( Foo@A foo ) {
-					this.take( foo.bar.bar.baz );
+		String src = """
+				package test;
+				class Leaf@D {
+					public Integer@D baz;
+					public Leaf( Integer@D baz ) { this.baz = baz; }
 				}
-			}
-			""";
+				class Middle@D {
+					public Leaf@D bar;
+					public Middle( Leaf@D bar ) { this.bar = bar; }
+				}
+				class Foo@D {
+					public Middle@D bar;
+					public Foo( Middle@D bar ) { this.bar = bar; }
+				}
+				class C@( A ) {
+					public void take( Integer@A x ) {}
+					public void run( Foo@A foo ) {
+						this.take( foo.bar.bar.baz );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( src ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsDeepScopedFieldAccessAsWhole() throws IOException {
-		String src =
-			"""
-			package test;
-			class Leaf@D {
-				public Integer@D baz;
-				public Leaf( Integer@D baz ) { this.baz = baz; }
-			}
-			class Middle@D {
-				public Leaf@D bar;
-				public Middle( Leaf@D bar ) { this.bar = bar; }
-			}
-			class Foo@D {
-				public Middle@D bar;
-				public Foo( Middle@D bar ) { this.bar = bar; }
-			}
-			class C@( A, B ) {
-				public void take( Integer@A x ) {}
-				public void run( Foo@B foo ) {
-					this.take( foo.bar.bar.baz );
+		String src = """
+				package test;
+				class Leaf@D {
+					public Integer@D baz;
+					public Leaf( Integer@D baz ) { this.baz = baz; }
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Leaf@D {
-				public Integer@D baz;
-				public Leaf( Integer@D baz ) { this.baz = baz; }
-			}
-			class Middle@D {
-				public Leaf@D bar;
-				public Middle( Leaf@D bar ) { this.bar = bar; }
-			}
-			class Foo@D {
-				public Middle@D bar;
-				public Foo( Middle@D bar ) { this.bar = bar; }
-			}
-			class C@( A, B ) {
-				public void take( Integer@A x ) {}
-				public void run( Foo@B foo ) {
-					Integer@A msg0 = foo.bar.bar.baz;
-					this.take( msg0 );
+				class Middle@D {
+					public Leaf@D bar;
+					public Middle( Leaf@D bar ) { this.bar = bar; }
 				}
-			}
-		""";
+				class Foo@D {
+					public Middle@D bar;
+					public Foo( Middle@D bar ) { this.bar = bar; }
+				}
+				class C@( A, B ) {
+					public void take( Integer@A x ) {}
+					public void run( Foo@B foo ) {
+						this.take( foo.bar.bar.baz );
+					}
+				}
+				""";
+		String expected = """
+				package test;
+				class Leaf@D {
+					public Integer@D baz;
+					public Leaf( Integer@D baz ) { this.baz = baz; }
+				}
+				class Middle@D {
+					public Leaf@D bar;
+					public Middle( Leaf@D bar ) { this.bar = bar; }
+				}
+				class Foo@D {
+					public Middle@D bar;
+					public Foo( Middle@D bar ) { this.bar = bar; }
+				}
+				class C@( A, B ) {
+					public void take( Integer@A x ) {}
+					public void run( Foo@B foo ) {
+						Integer@A msg0 = foo.bar.bar.baz;
+						this.take( msg0 );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void deduplicatesRepeatedPureVariableHoists() throws IOException {
-		String src =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B ) {
-				public void takeB( Thing@B first, Thing@B second ) {}
-				public void run( Thing@A y ) {
-					this.takeB( y, y );
+		String src = """
+				package test;
+				class Thing@D {}
+				class C@( A, B ) {
+					public void takeB( Thing@B first, Thing@B second ) {}
+					public void run( Thing@A y ) {
+						this.takeB( y, y );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B ) {
-				public void takeB( Thing@B first, Thing@B second ) {}
-				public void run( Thing@A y ) {
-					Thing@B msg0 = y;
-					this.takeB( msg0, msg0 );
+				""";
+		String expected = """
+				package test;
+				class Thing@D {}
+				class C@( A, B ) {
+					public void takeB( Thing@B first, Thing@B second ) {}
+					public void run( Thing@A y ) {
+						Thing@B msg0 = y;
+						this.takeB( msg0, msg0 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void deduplicatesRepeatedPureScopedFieldHoists() throws IOException {
-		String src =
-			"""
-			package test;
-			class Bar@D {}
-			class Foo@D { public Bar@D bar; }
-			class Thing@D { public Foo@D foo; }
-			class C@( A, B ) {
-				public void takeB( Bar@B first, Bar@B second ) {}
-				public void run( Thing@A y ) {
-					this.takeB( y.foo.bar, y.foo.bar );
+		String src = """
+				package test;
+				class Bar@D {}
+				class Foo@D { public Bar@D bar; }
+				class Thing@D { public Foo@D foo; }
+				class C@( A, B ) {
+					public void takeB( Bar@B first, Bar@B second ) {}
+					public void run( Thing@A y ) {
+						this.takeB( y.foo.bar, y.foo.bar );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Bar@D {}
-			class Foo@D { public Bar@D bar; }
-			class Thing@D { public Foo@D foo; }
-			class C@( A, B ) {
-				public void takeB( Bar@B first, Bar@B second ) {}
-				public void run( Thing@A y ) {
-					Bar@B msg0 = y.foo.bar;
-					this.takeB( msg0, msg0 );
+				""";
+		String expected = """
+				package test;
+				class Bar@D {}
+				class Foo@D { public Bar@D bar; }
+				class Thing@D { public Foo@D foo; }
+				class C@( A, B ) {
+					public void takeB( Bar@B first, Bar@B second ) {}
+					public void run( Thing@A y ) {
+						Bar@B msg0 = y.foo.bar;
+						this.takeB( msg0, msg0 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
-	public void doesNotDeduplicateSamePureExpressionAcrossDifferentExpectedWorlds() throws IOException {
-		String src =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B, D ) {
-				public void takeBoth( Thing@B atB, Thing@D atD ) {}
-				public void run( Thing@A y ) {
-					this.takeBoth( y, y );
+	public void doesNotDeduplicateSamePureExpressionAcrossDifferentExpectedWorlds()
+			throws IOException {
+		String src = """
+				package test;
+				class Thing@D {}
+				class C@( A, B, D ) {
+					public void takeBoth( Thing@B atB, Thing@D atD ) {}
+					public void run( Thing@A y ) {
+						this.takeBoth( y, y );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B, D ) {
-				public void takeBoth( Thing@B atB, Thing@D atD ) {}
-				public void run( Thing@A y ) {
-					Thing@B msg0 = y;
-					Thing@D msg1 = y;
-					this.takeBoth( msg0, msg1 );
+				""";
+		String expected = """
+				package test;
+				class Thing@D {}
+				class C@( A, B, D ) {
+					public void takeBoth( Thing@B atB, Thing@D atD ) {}
+					public void run( Thing@A y ) {
+						Thing@B msg0 = y;
+						Thing@D msg1 = y;
+						this.takeBoth( msg0, msg1 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void doesNotDeduplicateRepeatedImpureMethodCallHoists() throws IOException {
-		String src =
-			"""
-			package test;
-			class Bar@D {}
-			class Foo@D {
-				public Bar@D bar;
-				public Bar@D baz() { return bar; }
-			}
-			class Thing@D { public Foo@D foo; }
-			class C@( A, B ) {
-				public void takeB( Bar@B first, Bar@B second ) {}
-				public void run( Thing@A y ) {
-					this.takeB( y.foo.baz(), y.foo.baz() );
+		String src = """
+				package test;
+				class Bar@D {}
+				class Foo@D {
+					public Bar@D bar;
+					public Bar@D baz() { return bar; }
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Bar@D {}
-			class Foo@D {
-				public Bar@D bar;
-				public Bar@D baz() { return bar; }
-			}
-			class Thing@D { public Foo@D foo; }
-			class C@( A, B ) {
-				public void takeB( Bar@B first, Bar@B second ) {}
-				public void run( Thing@A y ) {
-					Bar@B msg0 = y.foo.baz();
-					Bar@B msg1 = y.foo.baz();
-					this.takeB( msg0, msg1 );
+				class Thing@D { public Foo@D foo; }
+				class C@( A, B ) {
+					public void takeB( Bar@B first, Bar@B second ) {}
+					public void run( Thing@A y ) {
+						this.takeB( y.foo.baz(), y.foo.baz() );
+					}
 				}
-			}
-			""";
+				""";
+		String expected = """
+				package test;
+				class Bar@D {}
+				class Foo@D {
+					public Bar@D bar;
+					public Bar@D baz() { return bar; }
+				}
+				class Thing@D { public Foo@D foo; }
+				class C@( A, B ) {
+					public void takeB( Bar@B first, Bar@B second ) {}
+					public void run( Thing@A y ) {
+						Bar@B msg0 = y.foo.baz();
+						Bar@B msg1 = y.foo.baz();
+						this.takeB( msg0, msg1 );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void deduplicatesOnlyPureHoistsInMixedExpressionList() throws IOException {
-		String src =
-			"""
-			package test;
-			class Bar@D {}
-			class Foo@D {
-				public Bar@D bar;
-				public Bar@D baz() { return bar; }
-			}
-			class Thing@D { public Foo@D foo; }
-			class C@( A, B ) {
-				public Integer@B takeB(
-					Thing@B t1, Thing@B t2,
-					Bar@B b1, Bar@B b2,
-					Bar@B c1, Bar@B c2 ) { return 0@B; }
-				public void run( Thing@A y ) {
-					Integer@B x = this.takeB(
-						y, y, y.foo.bar, y.foo.bar, y.foo.baz(), y.foo.baz() );
+		String src = """
+				package test;
+				class Bar@D {}
+				class Foo@D {
+					public Bar@D bar;
+					public Bar@D baz() { return bar; }
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Bar@D {}
-			class Foo@D {
-				public Bar@D bar;
-				public Bar@D baz() { return bar; }
-			}
-			class Thing@D { public Foo@D foo; }
-			class C@( A, B ) {
-				public Integer@B takeB(
-					Thing@B t1, Thing@B t2,
-					Bar@B b1, Bar@B b2,
-					Bar@B c1, Bar@B c2 ) { return 0@B; }
-				public void run( Thing@A y ) {
-					Thing@B msg0 = y;
-					Bar@B msg1 = y.foo.bar;
-					Bar@B msg2 = y.foo.baz();
-					Bar@B msg3 = y.foo.baz();
-					Integer@B x = this.takeB(
-						msg0, msg0, msg1, msg1, msg2, msg3 );
+				class Thing@D { public Foo@D foo; }
+				class C@( A, B ) {
+					public Integer@B takeB(
+						Thing@B t1, Thing@B t2,
+						Bar@B b1, Bar@B b2,
+						Bar@B c1, Bar@B c2 ) { return 0@B; }
+					public void run( Thing@A y ) {
+						Integer@B x = this.takeB(
+							y, y, y.foo.bar, y.foo.bar, y.foo.baz(), y.foo.baz() );
+					}
 				}
-			}
-			""";
+				""";
+		String expected = """
+				package test;
+				class Bar@D {}
+				class Foo@D {
+					public Bar@D bar;
+					public Bar@D baz() { return bar; }
+				}
+				class Thing@D { public Foo@D foo; }
+				class C@( A, B ) {
+					public Integer@B takeB(
+						Thing@B t1, Thing@B t2,
+						Bar@B b1, Bar@B b2,
+						Bar@B c1, Bar@B c2 ) { return 0@B; }
+					public void run( Thing@A y ) {
+						Thing@B msg0 = y;
+						Bar@B msg1 = y.foo.bar;
+						Bar@B msg2 = y.foo.baz();
+						Bar@B msg3 = y.foo.baz();
+						Integer@B x = this.takeB(
+							msg0, msg0, msg1, msg1, msg2, msg3 );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void doesNotReusePureHoistDeclaredOnlyInsideChildScope() throws IOException {
-		String src =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B ) {
-				public void takeB( Thing@B y ) {}
-				public void run( Boolean@A cond, Thing@A y ) {
-					if( cond ) { this.takeB( y ); } else { }
-					this.takeB( y );
+		String src = """
+				package test;
+				class Thing@D {}
+				class C@( A, B ) {
+					public void takeB( Thing@B y ) {}
+					public void run( Boolean@A cond, Thing@A y ) {
+						if( cond ) { this.takeB( y ); } else { }
+						this.takeB( y );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B ) {
-				public void takeB( Thing@B y ) {}
-				public void run( Boolean@A cond, Thing@A y ) {
-					if( cond ) { Thing@B msg0 = y; this.takeB( msg0 ); } else { }
-					Thing@B msg1 = y;
-					this.takeB( msg1 );
+				""";
+		String expected = """
+				package test;
+				class Thing@D {}
+				class C@( A, B ) {
+					public void takeB( Thing@B y ) {}
+					public void run( Boolean@A cond, Thing@A y ) {
+						if( cond ) { Thing@B msg0 = y; this.takeB( msg0 ); } else { }
+						Thing@B msg1 = y;
+						this.takeB( msg1 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsStaticCallArgumentAndWholeStaticCall() throws IOException {
-		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run() {
-					Integer@A x = Integer@B.valueOf( 42@A );
+		String src = """
+				package test;
+				class C@( A, B ) {
+					public void run() {
+						Integer@A x = Integer@B.valueOf( 42@A );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run() {
-					Integer@B msg0 = 42@A;
-					Integer@A msg1 = Integer@B.valueOf( msg0 );
-					Integer@A x = msg1;
+				""";
+		String expected = """
+				package test;
+				class C@( A, B ) {
+					public void run() {
+						Integer@B msg0 = 42@A;
+						Integer@A msg1 = Integer@B.valueOf( msg0 );
+						Integer@A x = msg1;
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsEnumCaseInstantiation() throws IOException {
-		String src =
-			"""
-			package test;
-			enum Choice@R { YES, NO }
-			class C@( A, B ) {
-				public void take( Choice@A choice ) {}
-				public void run() {
-					this.take( Choice@B.YES );
+		String src = """
+				package test;
+				enum Choice@R { YES, NO }
+				class C@( A, B ) {
+					public void take( Choice@A choice ) {}
+					public void run() {
+						this.take( Choice@B.YES );
+					}
 				}
-			}
-			""";
-		String expected =
-			"""
-			package test;
-			enum Choice@R { YES, NO }
-			class C@( A, B ) {
-				public void take( Choice@A choice ) {}
-				public void run() {
-					Choice@A msg0 = Choice@B.YES;
-					this.take( msg0 );
+				""";
+		String expected = """
+				package test;
+				enum Choice@R { YES, NO }
+				class C@( A, B ) {
+					public void take( Choice@A choice ) {}
+					public void run() {
+						Choice@A msg0 = Choice@B.YES;
+						this.take( msg0 );
+					}
 				}
-			}
-			""";
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void hoistsCrossWorldLiteralsAndNull() throws IOException {
-		String src =
-			"""
-			package test;
-			class Box@D {}
-			class C@( A, B ) {
-				public void take( Integer@A i, Boolean@A b, String@A s, Box@A box ) {}
-				public void run() {
-					this.take( 1@B, true@B, "x"@B, null@B );
+		String src = """
+				package test;
+				class Box@D {}
+				class C@( A, B ) {
+					public void take( Integer@A i, Boolean@A b, String@A s, Box@A box ) {}
+					public void run() {
+						this.take( 1@B, true@B, "x"@B, null@B );
+					}
 				}
-			}
-			""";
+				""";
 		String expected =
-			"""
-			package test;
-			class Box@D {}
-			class C@( A, B ) {
-				public void take( Integer@A i, Boolean@A b, String@A s, Box@A box ) {}
-				public void run() {
-					Integer@A msg0 = 1@B;
-					Boolean@A msg1 = true@B;
-					String@A msg2 = "x"@B;
-					Box@A msg3 = null@B;
-					this.take( msg0, msg1, msg2, msg3 );
-				}
-			}
-			""";
+				"""
+						package test;
+						class Box@D {}
+						class C@( A, B ) {
+							public void take( Integer@A i, Boolean@A b, String@A s, Box@A box ) {}
+							public void run() {
+								Integer@A msg0 = 1@B;
+								Boolean@A msg1 = true@B;
+								String@A msg2 = "x"@B;
+								Box@A msg3 = null@B;
+								this.take( msg0, msg1, msg2, msg3 );
+							}
+						}
+						""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void normalizesHoistsInsideScopedExpressionScope() throws IOException {
 		String src =
-			"""
-			package test;
-			class Box@D {
-				public Integer@D value;
-				public Box( Integer@D value ) { this.value = value; }
-			}
-			class C@( A, B ) {
-				public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
-				public void take( Integer@A value ) {}
-				public void run( Integer@B b ) {
-					this.take( this.getBox( b ).value );
-				}
-			}
-			""";
+				"""
+						package test;
+						class Box@D {
+							public Integer@D value;
+							public Box( Integer@D value ) { this.value = value; }
+						}
+						class C@( A, B ) {
+							public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
+							public void take( Integer@A value ) {}
+							public void run( Integer@B b ) {
+								this.take( this.getBox( b ).value );
+							}
+						}
+						""";
 		String expected =
-			"""
-			package test;
-			class Box@D {
-				public Integer@D value;
-				public Box( Integer@D value ) { this.value = value; }
-			}
-			class C@( A, B ) {
-				public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
-				public void take( Integer@A value ) {}
-				public void run( Integer@B b ) {
-					Integer@A msg0 = b;
-					this.take( this.getBox( msg0 ).value );
-				}
-			}
-			""";
+				"""
+						package test;
+						class Box@D {
+							public Integer@D value;
+							public Box( Integer@D value ) { this.value = value; }
+						}
+						class C@( A, B ) {
+							public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
+							public void take( Integer@A value ) {}
+							public void run( Integer@B b ) {
+								Integer@A msg0 = b;
+								this.take( this.getBox( msg0 ).value );
+							}
+						}
+						""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void normalizesSwitchGuardAndCaseBodies() throws IOException {
 		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run( Integer@A a, Integer@B b ) {
-					switch( b + a ) {
-						case 0@B -> { Integer@A x = b; }
-						default -> { Integer@A y = b; }
-					}
-				}
-			}
-			""";
+				"""
+						package test;
+						class C@( A, B ) {
+							public void run( Integer@A a, Integer@B b ) {
+								switch( b + a ) {
+									case 0@B -> { Integer@A x = b; }
+									default -> { Integer@A y = b; }
+								}
+							}
+						}
+						""";
 		String expected =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run( Integer@A a, Integer@B b ) {
-					Integer@B msg0 = a;
-					switch( b + msg0 ) {
-						case 0@B -> { Integer@A msg1 = b; Integer@A x = msg1; }
-						default -> { Integer@A msg2 = b; Integer@A y = msg2; }
-					}
-				}
-			}
-			""";
+				"""
+						package test;
+						class C@( A, B ) {
+							public void run( Integer@A a, Integer@B b ) {
+								Integer@B msg0 = a;
+								switch( b + msg0 ) {
+									case 0@B -> { Integer@A msg1 = b; Integer@A x = msg1; }
+									default -> { Integer@A msg2 = b; Integer@A y = msg2; }
+								}
+							}
+						}
+						""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
 	@Test
 	public void recordsPureVariableHoistMetadata() throws IOException {
 		String src =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B ) {
-				public void takeB( Thing@B y ) {}
-				public void run( Thing@A y ) {
-					this.takeB( y );
-				}
-			}
-			""";
+				"""
+						package test;
+						class Thing@D {}
+						class C@( A, B ) {
+							public void takeB( Thing@B y ) {}
+							public void run( Thing@A y ) {
+								this.takeB( y );
+							}
+						}
+						""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 1, hoists.size() );
 		assertEquals( "msg0", hoists.get( 0 ).name().identifier() );
 		assertEquals( "Thing", hoists.get( 0 ).type().get().name().identifier() );
-		assertEquals( "B", hoists.get( 0 ).type().get().worldArguments().get( 0 ).name().identifier() );
+		assertEquals( "B",
+				hoists.get( 0 ).type().get().worldArguments().get( 0 ).name().identifier() );
 		assertTrue( hoists.get( 0 ).initializer().isPresent() );
 	}
 
 	@Test
 	public void recordsDeduplicatedPureHoistOnce() throws IOException {
 		String src =
-			"""
-			package test;
-			class Thing@D {}
-			class C@( A, B ) {
-				public void takeB( Thing@B y1, Thing@B y2 ) {}
-				public void run( Thing@A y ) {
-					this.takeB( y, y );
-				}
-			}
-			""";
+				"""
+						package test;
+						class Thing@D {}
+						class C@( A, B ) {
+							public void takeB( Thing@B y1, Thing@B y2 ) {}
+							public void run( Thing@A y ) {
+								this.takeB( y, y );
+							}
+						}
+						""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 1, hoists.size() );
@@ -964,18 +919,18 @@ public class NormalizerTest {
 	@Test
 	public void recordsRepeatedImpureHoistsSeparately() throws IOException {
 		String src =
-			"""
-			package test;
-			class Bar@D {}
-			class Foo@D { public Bar@D baz() { return new Bar@D(); } }
-			class Thing@D { public Foo@D foo; }
-			class C@( A, B ) {
-				public void takeB( Bar@B b1, Bar@B b2 ) {}
-				public void run( Thing@A y ) {
-					this.takeB( y.foo.baz(), y.foo.baz() );
-				}
-			}
-			""";
+				"""
+						package test;
+						class Bar@D {}
+						class Foo@D { public Bar@D baz() { return new Bar@D(); } }
+						class Thing@D { public Foo@D foo; }
+						class C@( A, B ) {
+							public void takeB( Bar@B b1, Bar@B b2 ) {}
+							public void run( Thing@A y ) {
+								this.takeB( y.foo.baz(), y.foo.baz() );
+							}
+						}
+						""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 2, hoists.size() );
@@ -986,17 +941,17 @@ public class NormalizerTest {
 	@Test
 	public void recordsHoistsInsideChildScopesForEnclosingMethod() throws IOException {
 		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public void run( Integer@A a, Integer@B b ) {
-					switch( b + a ) {
-						case 0@B -> { Integer@A x = b; }
-						default -> { Integer@A y = b; }
-					}
-				}
-			}
-			""";
+				"""
+						package test;
+						class C@( A, B ) {
+							public void run( Integer@A a, Integer@B b ) {
+								switch( b + a ) {
+									case 0@B -> { Integer@A x = b; }
+									default -> { Integer@A y = b; }
+								}
+							}
+						}
+						""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 3, hoists.size() );
@@ -1008,58 +963,59 @@ public class NormalizerTest {
 	@Test
 	public void recordsConstructorHoistMetadata() throws IOException {
 		String src =
-			"""
-			package test;
-			class C@( A, B ) {
-				public C( Integer@B b ) {
-					this.takeA( b );
-				}
-				public void takeA( Integer@A x ) {}
-			}
-			""";
+				"""
+						package test;
+						class C@( A, B ) {
+							public C( Integer@B b ) {
+								this.takeA( b );
+							}
+							public void takeA( Integer@A x ) {}
+						}
+						""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForConstructor( result, "C" );
 		assertEquals( 1, hoists.size() );
 		assertEquals( "msg0", hoists.get( 0 ).name().identifier() );
 		assertEquals( "Integer", hoists.get( 0 ).type().get().name().identifier() );
-		assertEquals( "A", hoists.get( 0 ).type().get().worldArguments().get( 0 ).name().identifier() );
+		assertEquals( "A",
+				hoists.get( 0 ).type().get().worldArguments().get( 0 ).name().identifier() );
 	}
 
 	@Test
 	public void increments() throws IOException {
 		String src =
 				"""
-				package MoveMeant.Increments;
-				
-				import choral.channels.SymChannel;
-				
-				class Increments@( A, B ) {
-					public void fun( SymChannel@( A, B )< Object > ch_AB ) {
-						Boolean@B b3 = true@B;
-						Boolean@A a3 = b3 && false@A;
-						b3 &= a3 || true@B;
-						a3 |= false@A || b3;
-					}
-				}
-				""";
+						package MoveMeant.Increments;
+
+						import choral.channels.SymChannel;
+
+						class Increments@( A, B ) {
+							public void fun( SymChannel@( A, B )< Object > ch_AB ) {
+								Boolean@B b3 = true@B;
+								Boolean@A a3 = b3 && false@A;
+								b3 &= a3 || true@B;
+								a3 |= false@A || b3;
+							}
+						}
+						""";
 		String expected =
 				"""
-				package MoveMeant.Increments;
+						package MoveMeant.Increments;
 
-				import choral.channels.SymChannel;
+						import choral.channels.SymChannel;
 
-				class Increments@(A, B) {
-					public void fun( SymChannel@( A, B )< Object > ch_AB ) {
-						Boolean@( B ) b3 = true@B;
-						Boolean@( A ) msg0 = b3;
-						Boolean@( A ) a3 = msg0 && false@A;
-						Boolean@( B ) msg1 = a3;
-						b3 &= msg1 || true@B;
-						a3 |= false@A || msg0;
-					}
+						class Increments@(A, B) {
+							public void fun( SymChannel@( A, B )< Object > ch_AB ) {
+								Boolean@( B ) b3 = true@B;
+								Boolean@( A ) msg0 = b3;
+								Boolean@( A ) a3 = msg0 && false@A;
+								Boolean@( B ) msg1 = a3;
+								b3 &= msg1 || true@B;
+								a3 |= false@A || msg0;
+							}
 
-				}
-				""";
+						}
+						""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 }

--- a/choral/src/test/java/NormalizerTest.java
+++ b/choral/src/test/java/NormalizerTest.java
@@ -937,8 +937,8 @@ public class NormalizerTest {
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 1, hoists.size() );
 		assertEquals( "msg0", hoists.get( 0 ).name().identifier() );
-		assertEquals( "Thing", hoists.get( 0 ).type().name().identifier() );
-		assertEquals( "B", hoists.get( 0 ).type().worldArguments().get( 0 ).name().identifier() );
+		assertEquals( "Thing", hoists.get( 0 ).type().get().name().identifier() );
+		assertEquals( "B", hoists.get( 0 ).type().get().worldArguments().get( 0 ).name().identifier() );
 		assertTrue( hoists.get( 0 ).initializer().isPresent() );
 	}
 
@@ -1021,8 +1021,8 @@ public class NormalizerTest {
 		List< VariableDeclaration > hoists = hoistsForConstructor( result, "C" );
 		assertEquals( 1, hoists.size() );
 		assertEquals( "msg0", hoists.get( 0 ).name().identifier() );
-		assertEquals( "Integer", hoists.get( 0 ).type().name().identifier() );
-		assertEquals( "A", hoists.get( 0 ).type().worldArguments().get( 0 ).name().identifier() );
+		assertEquals( "Integer", hoists.get( 0 ).type().get().name().identifier() );
+		assertEquals( "A", hoists.get( 0 ).type().get().worldArguments().get( 0 ).name().identifier() );
 	}
 
 	@Test

--- a/choral/src/test/java/NormalizerTest.java
+++ b/choral/src/test/java/NormalizerTest.java
@@ -86,7 +86,8 @@ public class NormalizerTest {
 
 	@Test
 	public void emptyClass() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Empty@( A ) { }
 				""";
@@ -95,7 +96,8 @@ public class NormalizerTest {
 
 	@Test
 	public void sameWorldAssignment() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class SameWorld@( A ) {
 					public void m() {
@@ -109,7 +111,8 @@ public class NormalizerTest {
 
 	@Test
 	public void sameWorldMethodCall() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A ) {
 					public Integer@A m( Integer@A x ) { return x; }
@@ -123,7 +126,8 @@ public class NormalizerTest {
 
 	@Test
 	public void sameWorldIfReturn() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A ) {
 					public Integer@A m( Boolean@A b ) {
@@ -136,7 +140,8 @@ public class NormalizerTest {
 
 	@Test
 	public void sameWorldBlockAndNot() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A ) {
 					public Boolean@A m( Boolean@A b ) {
@@ -149,7 +154,8 @@ public class NormalizerTest {
 
 	@Test
 	public void sameWorldEnclosed() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A ) {
 					public Integer@A m() {
@@ -163,7 +169,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsCrossWorldMethodArg() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A take( Integer@A x ) { return x; }
@@ -172,7 +179,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A take( Integer@A x ) { return x; }
@@ -187,7 +195,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsTwoCrossWorldArgsInOrder() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B, D ) {
 					public Integer@A take( Integer@A x, Integer@A y ) { return x; }
@@ -196,7 +205,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B, D ) {
 					public Integer@A take( Integer@A x, Integer@A y ) { return x; }
@@ -212,7 +222,8 @@ public class NormalizerTest {
 
 	@Test
 	public void sameWorldArgsNotHoisted() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A take( Integer@A x ) { return x; }
@@ -226,7 +237,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsCrossWorldBinaryRightOperand() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void run( Integer@A a, Integer@B b ) {
@@ -234,7 +246,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void run( Integer@A a, Integer@B b ) {
@@ -248,7 +261,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsCrossWorldAssignRhs() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void run( Integer@A a, Integer@B b ) {
@@ -256,7 +270,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 					package test;
 					class C@( A, B ) {
 						public void run( Integer@A a, Integer@B b ) {
@@ -270,7 +285,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsNestedAlternatingWorldMethodCallsInsideOut() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A takeA( Integer@A x ) { return x; }
@@ -280,7 +296,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A takeA( Integer@A x ) { return x; }
@@ -297,7 +314,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsThreeLevelAlternatingWorldMethodCallsInsideOut() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A takeA( Integer@A x ) { return x; }
@@ -307,7 +325,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A takeA( Integer@A x ) { return x; }
@@ -325,7 +344,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsNotExpressionAsWhole() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void take( Boolean@A x ) {}
@@ -334,7 +354,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void take( Boolean@A x ) {}
@@ -349,7 +370,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsEnclosedExpressionAsWhole() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void take( Integer@A x ) {}
@@ -358,7 +380,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 					package test;
 					class C@( A, B ) {
 						public void take( Integer@A x ) {}
@@ -373,7 +396,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsThisFieldAccessAsWhole() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A x;
@@ -383,7 +407,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B ) {
 					public Integer@A x;
@@ -399,7 +424,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsSuperFieldAccessAsWhole() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Base@( D, E ) {
 					public Integer@D x;
@@ -411,7 +437,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Base@( D, E ) {
 					public Integer@D x;
@@ -429,7 +456,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsScopedFieldAccess() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Pair@D {
 					public Integer@D x;
@@ -442,7 +470,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Pair@D {
 					public Integer@D x;
@@ -461,7 +490,8 @@ public class NormalizerTest {
 
 	@Test
 	public void sameWorldDeepScopedFieldAccessNotHoisted() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Leaf@D {
 					public Integer@D baz;
@@ -487,7 +517,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsDeepScopedFieldAccessAsWhole() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Leaf@D {
 					public Integer@D baz;
@@ -508,7 +539,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Leaf@D {
 					public Integer@D baz;
@@ -535,7 +567,8 @@ public class NormalizerTest {
 
 	@Test
 	public void deduplicatesRepeatedPureVariableHoists() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Thing@D {}
 				class C@( A, B ) {
@@ -545,7 +578,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Thing@D {}
 				class C@( A, B ) {
@@ -561,7 +595,8 @@ public class NormalizerTest {
 
 	@Test
 	public void deduplicatesRepeatedPureScopedFieldHoists() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Bar@D {}
 				class Foo@D { public Bar@D bar; }
@@ -573,7 +608,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Bar@D {}
 				class Foo@D { public Bar@D bar; }
@@ -592,7 +628,8 @@ public class NormalizerTest {
 	@Test
 	public void doesNotDeduplicateSamePureExpressionAcrossDifferentExpectedWorlds()
 			throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Thing@D {}
 				class C@( A, B, D ) {
@@ -602,7 +639,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Thing@D {}
 				class C@( A, B, D ) {
@@ -619,7 +657,8 @@ public class NormalizerTest {
 
 	@Test
 	public void doesNotDeduplicateRepeatedImpureMethodCallHoists() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Bar@D {}
 				class Foo@D {
@@ -634,7 +673,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Bar@D {}
 				class Foo@D {
@@ -656,7 +696,8 @@ public class NormalizerTest {
 
 	@Test
 	public void deduplicatesOnlyPureHoistsInMixedExpressionList() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Bar@D {}
 				class Foo@D {
@@ -675,7 +716,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Bar@D {}
 				class Foo@D {
@@ -703,7 +745,8 @@ public class NormalizerTest {
 
 	@Test
 	public void doesNotReusePureHoistDeclaredOnlyInsideChildScope() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Thing@D {}
 				class C@( A, B ) {
@@ -714,7 +757,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class Thing@D {}
 				class C@( A, B ) {
@@ -731,7 +775,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsStaticCallArgumentAndWholeStaticCall() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void run() {
@@ -739,7 +784,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				class C@( A, B ) {
 					public void run() {
@@ -754,7 +800,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsEnumCaseInstantiation() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				enum Choice@R { YES, NO }
 				class C@( A, B ) {
@@ -764,7 +811,8 @@ public class NormalizerTest {
 					}
 				}
 				""";
-		String expected = """
+		String expected =
+				"""
 				package test;
 				enum Choice@R { YES, NO }
 				class C@( A, B ) {
@@ -780,7 +828,8 @@ public class NormalizerTest {
 
 	@Test
 	public void hoistsCrossWorldLiteralsAndNull() throws IOException {
-		String src = """
+		String src =
+				"""
 				package test;
 				class Box@D {}
 				class C@( A, B ) {
@@ -792,19 +841,19 @@ public class NormalizerTest {
 				""";
 		String expected =
 				"""
-						package test;
-						class Box@D {}
-						class C@( A, B ) {
-							public void take( Integer@A i, Boolean@A b, String@A s, Box@A box ) {}
-							public void run() {
-								Integer@A msg0 = 1@B;
-								Boolean@A msg1 = true@B;
-								String@A msg2 = "x"@B;
-								Box@A msg3 = null@B;
-								this.take( msg0, msg1, msg2, msg3 );
-							}
-						}
-						""";
+				package test;
+				class Box@D {}
+				class C@( A, B ) {
+					public void take( Integer@A i, Boolean@A b, String@A s, Box@A box ) {}
+					public void run() {
+						Integer@A msg0 = 1@B;
+						Boolean@A msg1 = true@B;
+						String@A msg2 = "x"@B;
+						Box@A msg3 = null@B;
+						this.take( msg0, msg1, msg2, msg3 );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
@@ -812,35 +861,35 @@ public class NormalizerTest {
 	public void normalizesHoistsInsideScopedExpressionScope() throws IOException {
 		String src =
 				"""
-						package test;
-						class Box@D {
-							public Integer@D value;
-							public Box( Integer@D value ) { this.value = value; }
-						}
-						class C@( A, B ) {
-							public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
-							public void take( Integer@A value ) {}
-							public void run( Integer@B b ) {
-								this.take( this.getBox( b ).value );
-							}
-						}
-						""";
+				package test;
+				class Box@D {
+					public Integer@D value;
+					public Box( Integer@D value ) { this.value = value; }
+				}
+				class C@( A, B ) {
+					public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
+					public void take( Integer@A value ) {}
+					public void run( Integer@B b ) {
+						this.take( this.getBox( b ).value );
+					}
+				}
+				""";
 		String expected =
 				"""
-						package test;
-						class Box@D {
-							public Integer@D value;
-							public Box( Integer@D value ) { this.value = value; }
-						}
-						class C@( A, B ) {
-							public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
-							public void take( Integer@A value ) {}
-							public void run( Integer@B b ) {
-								Integer@A msg0 = b;
-								this.take( this.getBox( msg0 ).value );
-							}
-						}
-						""";
+				package test;
+				class Box@D {
+					public Integer@D value;
+					public Box( Integer@D value ) { this.value = value; }
+				}
+				class C@( A, B ) {
+					public Box@A getBox( Integer@A value ) { return new Box@A( value ); }
+					public void take( Integer@A value ) {}
+					public void run( Integer@B b ) {
+						Integer@A msg0 = b;
+						this.take( this.getBox( msg0 ).value );
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
@@ -848,29 +897,29 @@ public class NormalizerTest {
 	public void normalizesSwitchGuardAndCaseBodies() throws IOException {
 		String src =
 				"""
-						package test;
-						class C@( A, B ) {
-							public void run( Integer@A a, Integer@B b ) {
-								switch( b + a ) {
-									case 0@B -> { Integer@A x = b; }
-									default -> { Integer@A y = b; }
-								}
-							}
+				package test;
+				class C@( A, B ) {
+					public void run( Integer@A a, Integer@B b ) {
+						switch( b + a ) {
+							case 0@B -> { Integer@A x = b; }
+							default -> { Integer@A y = b; }
 						}
-						""";
+					}
+				}
+				""";
 		String expected =
 				"""
-						package test;
-						class C@( A, B ) {
-							public void run( Integer@A a, Integer@B b ) {
-								Integer@B msg0 = a;
-								switch( b + msg0 ) {
-									case 0@B -> { Integer@A msg1 = b; Integer@A x = msg1; }
-									default -> { Integer@A msg2 = b; Integer@A y = msg2; }
-								}
-							}
+				package test;
+				class C@( A, B ) {
+					public void run( Integer@A a, Integer@B b ) {
+						Integer@B msg0 = a;
+						switch( b + msg0 ) {
+							case 0@B -> { Integer@A msg1 = b; Integer@A x = msg1; }
+							default -> { Integer@A msg2 = b; Integer@A y = msg2; }
 						}
-						""";
+					}
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 
@@ -878,15 +927,15 @@ public class NormalizerTest {
 	public void recordsPureVariableHoistMetadata() throws IOException {
 		String src =
 				"""
-						package test;
-						class Thing@D {}
-						class C@( A, B ) {
-							public void takeB( Thing@B y ) {}
-							public void run( Thing@A y ) {
-								this.takeB( y );
-							}
-						}
-						""";
+				package test;
+				class Thing@D {}
+				class C@( A, B ) {
+					public void takeB( Thing@B y ) {}
+					public void run( Thing@A y ) {
+						this.takeB( y );
+					}
+				}
+				""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 1, hoists.size() );
@@ -901,15 +950,15 @@ public class NormalizerTest {
 	public void recordsDeduplicatedPureHoistOnce() throws IOException {
 		String src =
 				"""
-						package test;
-						class Thing@D {}
-						class C@( A, B ) {
-							public void takeB( Thing@B y1, Thing@B y2 ) {}
-							public void run( Thing@A y ) {
-								this.takeB( y, y );
-							}
-						}
-						""";
+				package test;
+				class Thing@D {}
+				class C@( A, B ) {
+					public void takeB( Thing@B y1, Thing@B y2 ) {}
+					public void run( Thing@A y ) {
+						this.takeB( y, y );
+					}
+				}
+				""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 1, hoists.size() );
@@ -920,17 +969,17 @@ public class NormalizerTest {
 	public void recordsRepeatedImpureHoistsSeparately() throws IOException {
 		String src =
 				"""
-						package test;
-						class Bar@D {}
-						class Foo@D { public Bar@D baz() { return new Bar@D(); } }
-						class Thing@D { public Foo@D foo; }
-						class C@( A, B ) {
-							public void takeB( Bar@B b1, Bar@B b2 ) {}
-							public void run( Thing@A y ) {
-								this.takeB( y.foo.baz(), y.foo.baz() );
-							}
-						}
-						""";
+				package test;
+				class Bar@D {}
+				class Foo@D { public Bar@D baz() { return new Bar@D(); } }
+				class Thing@D { public Foo@D foo; }
+				class C@( A, B ) {
+					public void takeB( Bar@B b1, Bar@B b2 ) {}
+					public void run( Thing@A y ) {
+						this.takeB( y.foo.baz(), y.foo.baz() );
+					}
+				}
+				""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 2, hoists.size() );
@@ -942,16 +991,16 @@ public class NormalizerTest {
 	public void recordsHoistsInsideChildScopesForEnclosingMethod() throws IOException {
 		String src =
 				"""
-						package test;
-						class C@( A, B ) {
-							public void run( Integer@A a, Integer@B b ) {
-								switch( b + a ) {
-									case 0@B -> { Integer@A x = b; }
-									default -> { Integer@A y = b; }
-								}
-							}
+				package test;
+				class C@( A, B ) {
+					public void run( Integer@A a, Integer@B b ) {
+						switch( b + a ) {
+							case 0@B -> { Integer@A x = b; }
+							default -> { Integer@A y = b; }
 						}
-						""";
+					}
+				}
+				""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForMethod( result, "run" );
 		assertEquals( 3, hoists.size() );
@@ -964,14 +1013,14 @@ public class NormalizerTest {
 	public void recordsConstructorHoistMetadata() throws IOException {
 		String src =
 				"""
-						package test;
-						class C@( A, B ) {
-							public C( Integer@B b ) {
-								this.takeA( b );
-							}
-							public void takeA( Integer@A x ) {}
-						}
-						""";
+				package test;
+				class C@( A, B ) {
+					public C( Integer@B b ) {
+						this.takeA( b );
+					}
+					public void takeA( Integer@A x ) {}
+				}
+				""";
 		Normalizer.Result result = normalizeResult( src );
 		List< VariableDeclaration > hoists = hoistsForConstructor( result, "C" );
 		assertEquals( 1, hoists.size() );
@@ -985,37 +1034,37 @@ public class NormalizerTest {
 	public void increments() throws IOException {
 		String src =
 				"""
-						package MoveMeant.Increments;
+				package MoveMeant.Increments;
 
-						import choral.channels.SymChannel;
+				import choral.channels.SymChannel;
 
-						class Increments@( A, B ) {
-							public void fun( SymChannel@( A, B )< Object > ch_AB ) {
-								Boolean@B b3 = true@B;
-								Boolean@A a3 = b3 && false@A;
-								b3 &= a3 || true@B;
-								a3 |= false@A || b3;
-							}
-						}
-						""";
+				class Increments@( A, B ) {
+					public void fun( SymChannel@( A, B )< Object > ch_AB ) {
+						Boolean@B b3 = true@B;
+						Boolean@A a3 = b3 && false@A;
+						b3 &= a3 || true@B;
+						a3 |= false@A || b3;
+					}
+				}
+				""";
 		String expected =
 				"""
-						package MoveMeant.Increments;
+				package MoveMeant.Increments;
 
-						import choral.channels.SymChannel;
+				import choral.channels.SymChannel;
 
-						class Increments@(A, B) {
-							public void fun( SymChannel@( A, B )< Object > ch_AB ) {
-								Boolean@( B ) b3 = true@B;
-								Boolean@( A ) msg0 = b3;
-								Boolean@( A ) a3 = msg0 && false@A;
-								Boolean@( B ) msg1 = a3;
-								b3 &= msg1 || true@B;
-								a3 |= false@A || msg0;
-							}
+				class Increments@(A, B) {
+					public void fun( SymChannel@( A, B )< Object > ch_AB ) {
+						Boolean@( B ) b3 = true@B;
+						Boolean@( A ) msg0 = b3;
+						Boolean@( A ) a3 = msg0 && false@A;
+						Boolean@( B ) msg1 = a3;
+						b3 &= msg1 || true@B;
+						a3 |= false@A || msg0;
+					}
 
-						}
-						""";
+				}
+				""";
 		assertEquals( prettyPrint( expected ), normalize( src ) );
 	}
 }

--- a/tests/expectedOutput/MoveMeant/ChannelsAsFields/ChannelsAsFields_First.java
+++ b/tests/expectedOutput/MoveMeant/ChannelsAsFields/ChannelsAsFields_First.java
@@ -12,7 +12,7 @@ public class ChannelsAsFields_First {
 	SymChannel_A < Object > ch_AC;
 	DiDataChannel_A < Object > diData;
 	DiSelectChannel_A diSelect;
-	int var;
+	int firstValue;
 
 	ChannelsAsFields_First( SymChannel_A < Object > ch_AB, SymChannel_A < Object > ch_AC ) {
 		this.ch_AB = ch_AB;

--- a/tests/expectedOutput/Typer/VarInference/VarInference.java
+++ b/tests/expectedOutput/Typer/VarInference/VarInference.java
@@ -1,0 +1,20 @@
+package Typer.VarInference;
+
+import choral.annotations.Choreography;
+import java.math.BigInteger;
+
+@Choreography( role = "A", name = "VarInference" )
+class VarInference {
+	void run() {
+		int number = 5;
+		String text = "hello";
+		BigInteger integer = new BigInteger( "1999" );
+		int maximum = Math.max( number, 7 );
+		String copy = text;
+		final int constant = maximum;
+		System.out.println( integer );
+		System.out.println( copy );
+		System.out.println( constant );
+	}
+
+}

--- a/tests/src/main/choral/MustFail/Typer/FinalVarLocalVariableReassignment.ch
+++ b/tests/src/main/choral/MustFail/Typer/FinalVarLocalVariableReassignment.ch
@@ -1,0 +1,8 @@
+package Typer.FinalVarLocalVariableReassignment;
+
+class FinalVarLocalVariableReassignment@( A ) {
+	void run() {
+		final var x = 5@A;
+		x += 1@A; //! Cannot assign a value to final variable 'x'.
+	}
+}

--- a/tests/src/main/choral/MustFail/Typer/FinalVarReassignment.ch
+++ b/tests/src/main/choral/MustFail/Typer/FinalVarReassignment.ch
@@ -1,6 +1,6 @@
-package Typer.FinalVarLocalVariableReassignment;
+package Typer.FinalVarReassignment;
 
-class FinalVarLocalVariableReassignment@( A ) {
+class FinalVarReassignment@( A ) {
 	void run() {
 		final var x = 5@A;
 		x += 1@A; //! Cannot assign a value to final variable 'x'.

--- a/tests/src/main/choral/MustPass/MoveMeant/ChannelsAsFields/ChannelsAsFields.ch
+++ b/tests/src/main/choral/MustPass/MoveMeant/ChannelsAsFields/ChannelsAsFields.ch
@@ -12,7 +12,7 @@ public class ChannelsAsFields@( First, Second, C ){
 	SymChannel@( First, C )< Object > ch_AC;
 	DiDataChannel@( First, Second )< Object > diData;
 	DiSelectChannel@( First, Second ) diSelect;
-	int@First var;
+	int@First firstValue;
 	String@Second var2;
 	Object@C var3;
 

--- a/tests/src/main/choral/MustPass/Typer/VarInference.ch
+++ b/tests/src/main/choral/MustPass/Typer/VarInference.ch
@@ -1,0 +1,17 @@
+package Typer.VarInference;
+
+import java.math.BigInteger;
+
+class VarInference@( A ) {
+	void run() {
+		var number = 5@A;
+		var text = "hello"@A;
+		var integer = new BigInteger@A( "1999"@A );
+		var maximum = Math@A.max( number, 7@A );
+		var copy = text;
+		final var constant = maximum;
+		System@A.out.println( integer );
+		System@A.out.println( copy );
+		System@A.out.println( constant );
+	}
+}


### PR DESCRIPTION
This PR adds the long-awaited `var` keyword for local variable declarations:
```java
class VarInference@( A ) {
	void run() {
		var number = 5@A;
		var text = "hello"@A;
		var integer = new BigInteger@A( "1999"@A );
		var maximum = Math@A.max( number, 7@A );
		var copy = text;
		final var constant = maximum;
		System@A.out.println( integer );
		System@A.out.println( copy );
		System@A.out.println( constant );
	}
}
```
Specific changes:
* Add 'var' to parser
* Implement reify and unapplyWorlds methods
* Make variable declaration type expressions optional
* Implement var support in Typer
* Ran spotless